### PR TITLE
Add PR-time CI gate running unittests across all 7 along-track modules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,52 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  unittest:
+    name: ${{ matrix.module }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - bad_pass
+          - daily_files
+          - finalizer
+          - oer
+          - pipeline_init
+          - unifier
+          - xover
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            pipeline/pipeline_runtime/requirements.txt
+            pipeline/daily_file_gen/${{ matrix.module }}/requirements.txt
+            setup.py
+
+      - name: Install pipeline_runtime base
+        run: pip install -r pipeline/pipeline_runtime/requirements.txt
+
+      - name: Install ${{ matrix.module }} requirements
+        run: pip install -r pipeline/daily_file_gen/${{ matrix.module }}/requirements.txt
+
+      - name: Install shared utilities (editable)
+        run: pip install -e .
+
+      - name: Run unittests
+        working-directory: pipeline/daily_file_gen/${{ matrix.module }}
+        run: python -m unittest discover -s tests -t . -v

--- a/pipeline/daily_file_gen/daily_files/tests/test_bad_points.py
+++ b/pipeline/daily_file_gen/daily_files/tests/test_bad_points.py
@@ -1,10 +1,12 @@
 import dataclasses
 import unittest
+from unittest import mock
 import xarray as xr
 import numpy as np
 from datetime import datetime
 from daily_files.config.source_config import get_source_config
 from daily_files.ingestion.ingest import IngestedData
+from daily_files.processing.daily_file import DailyFile
 from daily_files.processing.gsfc_daily_file import GSFCDailyFile
 from daily_files.processing.s6_daily_file import S6DailyFile
 
@@ -118,8 +120,9 @@ def _bad_points_config(source_config, bad_time):
     )
 
 
+@mock.patch.object(DailyFile, "get_mss_values", return_value=0.0)
 class TestGSFCBadPoints(unittest.TestCase):
-    def test_bad_point_is_flagged(self):
+    def test_bad_point_is_flagged(self, _mss):
         date = datetime(2024, 3, 15)
         times = _times_for_date(date)
         bad_time = times[10].astype("datetime64[s]").item()
@@ -137,7 +140,7 @@ class TestGSFCBadPoints(unittest.TestCase):
         self.assertEqual(len(idx), 1, "bad_time not found in output dataset")
         self.assertTrue(ds["nasa_flag"].values[idx[0]], "bad_time should have nasa_flag=1")
 
-    def test_wrong_date_not_flagged_by_bad_points(self):
+    def test_wrong_date_not_flagged_by_bad_points(self, _mss):
         """bad_points for a different date should not affect the current date."""
         date = datetime(2024, 3, 15)
         times = _times_for_date(date)
@@ -157,8 +160,9 @@ class TestGSFCBadPoints(unittest.TestCase):
         self.assertIn("nasa_flag", ds)
 
 
+@mock.patch.object(DailyFile, "get_mss_values", return_value=0.0)
 class TestS6BadPoints(unittest.TestCase):
-    def test_bad_point_is_flagged(self):
+    def test_bad_point_is_flagged(self, _mss):
         date = datetime(2024, 5, 10)
         times = _times_for_date(date)
         bad_time = times[20].astype("datetime64[s]").item()
@@ -176,7 +180,7 @@ class TestS6BadPoints(unittest.TestCase):
         self.assertEqual(len(idx), 1, "bad_time not found in output dataset")
         self.assertTrue(ds["nasa_flag"].values[idx[0]], "bad_time should have nasa_flag=1")
 
-    def test_no_bad_points_no_change(self):
+    def test_no_bad_points_no_change(self, _mss):
         """With bad_points=None, processing should not raise and produce valid flags."""
         date = datetime(2024, 5, 10)
         times = _times_for_date(date)
@@ -191,7 +195,7 @@ class TestS6BadPoints(unittest.TestCase):
         for v in flag_vals:
             self.assertIn(v, [0, 1, True, False])
 
-    def test_multiple_bad_points_all_flagged(self):
+    def test_multiple_bad_points_all_flagged(self, _mss):
         """All times listed under a date should be flagged."""
         date = datetime(2024, 5, 10)
         times = _times_for_date(date)

--- a/pipeline/daily_file_gen/daily_files/tests/test_gsfc_processing.py
+++ b/pipeline/daily_file_gen/daily_files/tests/test_gsfc_processing.py
@@ -1,10 +1,12 @@
 import logging
 import unittest
+from unittest import mock
 import xarray as xr
 import numpy as np
 from datetime import datetime
 from daily_files.config.source_config import get_source_config
 from daily_files.ingestion.ingest import IngestedData
+from daily_files.processing.daily_file import DailyFile
 from daily_files.processing.gsfc_daily_file import GSFCDailyFile
 from daily_files.daily_file_job import save_ds
 from daily_files.config.dataset_schema import validate_dataset
@@ -83,6 +85,10 @@ class TestGSFCProcessing(unittest.TestCase):
             format="[%(levelname)s] %(asctime)s - %(message)s",
             handlers=[logging.StreamHandler()],
         )
+
+        mss_patcher = mock.patch.object(DailyFile, "get_mss_values", return_value=0.0)
+        mss_patcher.start()
+        cls.addClassCleanup(mss_patcher.stop)
 
         cls.date = datetime(1995, 6, 7)
         source_config = get_source_config("GSFC")

--- a/pipeline/daily_file_gen/daily_files/tests/test_s6_processing.py
+++ b/pipeline/daily_file_gen/daily_files/tests/test_s6_processing.py
@@ -1,5 +1,6 @@
 import logging
 import unittest
+from unittest import mock
 import xarray as xr
 import numpy as np
 from datetime import datetime
@@ -7,6 +8,7 @@ from daily_files.config.source_config import get_source_config
 from daily_files.ingestion.ingest import IngestedData
 from daily_files.daily_file_job import save_ds
 from daily_files.config.dataset_schema import validate_dataset
+from daily_files.processing.daily_file import DailyFile
 from daily_files.processing.s6_daily_file import S6DailyFile
 
 
@@ -85,6 +87,10 @@ class TestS6Processing(unittest.TestCase):
             format="[%(levelname)s] %(asctime)s - %(message)s",
             handlers=[logging.StreamHandler()],
         )
+
+        mss_patcher = mock.patch.object(DailyFile, "get_mss_values", return_value=0.0)
+        mss_patcher.start()
+        cls.addClassCleanup(mss_patcher.stop)
 
         cls.date = datetime(2023, 12, 17)
         source_config = get_source_config("S6")


### PR DESCRIPTION
  ## Summary
  - Add `.github/workflows/tests.yml` running `python -m unittest discover tests` for each module under `pipeline/daily_file_gen/` (bad_pass, daily_files, finalizer, oer, pipeline_init, unifier, xover) on PR + push to main.
  - Each job installs `pipeline_runtime/requirements.txt`, the module's `requirements.txt`, then `pip install -e .` — mirrors the devcontainer venv layering.
  - `concurrency` block cancels superseded PR runs; main pushes are never cancelled.
  - `fail-fast: false` so one module's failure doesn't mask others. 

  ## Follow-ups (not in this PR)
  - Enable branch protection on `main` requiring all 7 matrix jobs to pass — can only be configured after the workflow has run once so GitHub knows the check names.