### PR TITLE
Add target registry as single source of truth for build/deploy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,25 @@ jobs:
       - name: Run unittests
         working-directory: pipeline/daily_file_gen/${{ matrix.module }}
         run: python -m unittest discover -s tests -t . -v
+
+  utilities:
+    name: utilities
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: setup.py
+
+      - name: Install shared utilities (editable)
+        run: pip install -e .
+
+      # Runs the Target registry tests, including the consistency check that
+      # pins targets.yaml to the filesystem (the registry's drift guard).
+      - name: Run unittests
+        run: python -m unittest discover -s utilities/tests -t . -v

--- a/docs/adr/0004-target-registry.md
+++ b/docs/adr/0004-target-registry.md
@@ -1,0 +1,51 @@
+# ADR 0004: Target registry as the single source of truth for build/deploy
+
+- **Status**: Accepted
+- **Date**: 2026-06-04
+
+## Context
+
+The build/deploy scripts (`scripts/dev/`, `scripts/prod/`, `scripts/util/`) had no single source of truth for what they manage. The knowledge of each build target was scattered:
+
+- **Existence + location** — re-derived by `find … -name "$IMAGE" | head -1` in both `dev/pipeline.sh` and `util/_build_and_push.sh`, and by `util/find_images.sh` walking Dockerfiles.
+- **Which images are "heavy"** (i.e. `FROM` pipeline_runtime via the `BASE_IMAGE` override) — a hardcoded `HEAVY_STAGES=(…)` array in `_build_and_push.sh`.
+- **Which images have no Lambda** — a hardcoded `BUILD_ONLY_IMAGES=(pipeline_runtime)` array duplicated in `dev/deploy.sh` and `prod/deploy.sh`.
+- **Naming conventions** — `${stage}/${name}` (ECR repo) and `${stage}-${name}` (function) re-spelled across three scripts.
+
+Two concrete consequences:
+
+1. **Stale dev deploys.** The dev loop rebuilds an image only if *its own directory* changed vs `main` (`git diff -- "$DIR"`). But every heavy stage `FROM`s pipeline_runtime and every stage `pip install`s the shared `utilities` package. A change to `utilities/`, root `setup.py`, or `pipeline_runtime/` changes the *content* of those images but touches no stage directory, so the loop silently skips the rebuild and deploys stale code on a green run.
+2. **Infra Lambdas had no deploy path.** The `pipeline/infra/` Lambdas (`failure_handling`, `podaac_auth`, `rewrite_manifest`, `set_sg_jobs`) are zip-packaged, not containerized. The scripts only ever handled container images, so these were deployed by hand.
+
+This is an **implicit, unowned contract** in the same spirit as the scientific-stack drift that motivated ADR 0001 — the knowledge of "what gets built and deployed, and how" lived in `find` calls and hand-maintained shell arrays with no test surface.
+
+## Decision
+
+Introduce a **Target registry** (`utilities/targets.py`, `utilities/targets.yaml`) as the one module the build/deploy scripts query. See CONTEXT.md → **Build & deploy** for the full vocabulary.
+
+- A **Target** is anything the scripts manage — a buildable image and/or a deployable Lambda.
+- **Existence** and **packaging kind** (`container` vs `zip`) are **derived from the filesystem**: a Dockerfile ⇒ `container`; an `app.py` under `pipeline/infra/` with no Dockerfile ⇒ `zip`.
+- The two facts that can't be reliably derived — **`heavy`** (brittle to grep for; see below) and **`deployable`** (a fact about what exists in AWS) — are **declared** in `targets.yaml`. The manifest is **path-less** so it survives the planned `pipeline/`→`src/` reorganization untouched.
+- `targets()` **raises if the manifest and filesystem disagree**, so every caller (not just the test) is protected from drift.
+- The registry exposes the catalog (with `ecr_repo` / `function_name` helpers) and a pure **change-impact** function (`dirty(changed_paths)`) encoding the real dependency edges: a container stage is dirty if its own dir, shared `utilities/` + `setup.py`, or (if heavy) `pipeline_runtime/` changed; a zip target is dirty only if its own dir changed.
+
+The build/deploy phases become filters over one catalog, with a **packaging seam**: build/push handles `container` targets; deploy iterates `deployable` targets and branches on packaging (`--image-uri` vs zip + `--zip-file`). This is where the infra Lambdas enter the loop.
+
+### Why declare `heavy` rather than derive it
+
+"Heavy" *is* derivable — a heavy image's Dockerfile parameterizes its base (`ARG BASE_IMAGE` / `FROM ${BASE_IMAGE}`) while lightweight ones use a literal `FROM`. But that derivation is a fragile grep contract: a Dockerfile reformat could silently reclassify a stage and build it on the wrong base. We declare `heavy` in `targets.yaml` and **guard the grep contract with a test** (`heavy` ⟺ Dockerfile parameterizes `BASE_IMAGE`), turning silent drift into a caught failure.
+
+## Consequences
+
+- `find_images.sh`, the `HEAVY_STAGES` / `BUILD_ONLY_IMAGES` arrays, the duplicated `find … -name` lookups (and their `| head -1` ambiguity), and the inline `git diff` gate all collapse into registry calls.
+- The change-impact logic gains a **test surface** for the first time: consistency, edge correctness, packaging derivation, and naming helpers are all unit-testable.
+- Reorg-robustness is concentrated in two places: the path-less manifest, and a single `_SHARED_BUILD_PATHS` constant in the module (the `utilities/`→`src/shared/` move updates one line).
+- The scripts now shell out to Python (`python -m utilities.targets …`). This is not a new dependency — the package is already installed for builds and tests.
+
+## Placement (and intended end-state)
+
+The registry lives in `utilities/` **for now**, chosen for least friction: that package already provided a free importable module (`python -m utilities.targets`), a `tests/` harness, and CI coverage — the test surface this design depends on. Standing up an equivalent from scratch in a new directory would have meant re-creating that packaging/import/CI plumbing.
+
+This is, however, a known compromise: the registry is **build-time tooling, not runtime**, but every stage Dockerfile does `COPY utilities/ … && pip install .`, so `targets.py` / `targets.yaml` currently get baked into every Lambda image. Harmless in size, but the wrong dependency direction (build tooling shipped inside the runtime artifact), and it splits the build subsystem across `utilities/` (registry) and `scripts/` (the scripts that consume it).
+
+**Intended end-state:** relocate the registry + scripts into a dedicated build package, out of the shipped runtime, to **land with the directory reorganization** (`REORGANIZATION_PLAN.md` → "Build tooling placement"). The registry must remain an importable, test-covered package so the consistency/change-impact drift guard keeps running in CI; the code touch-ups are small (module path in `registry.sh`, the `pipeline` walk roots and `_SHARED_BUILD_PATHS` constants in `targets.py`, `setup.py` packaging). Deferred rather than done now to avoid introducing a new top-level layout days before the reorg reshuffles every path.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,8 @@
 # Deployment Pipelines
 
-This directory contains scripts used to build, tag, push, and deploy Docker images for both **development** and **production** environments. The workflow is tightly integrated with Git to ensure traceability, reproducibility, and minimal rebuild effort.
+This directory contains scripts used to build, tag, push, and deploy the pipeline's Lambda **targets** for both **development** and **production** environments. The workflow is tightly integrated with Git to ensure traceability, reproducibility, and minimal rebuild effort.
+
+What each script manages — which targets exist, where they live, which are heavy (`FROM` pipeline_runtime), which map to a Lambda, and how they are packaged — comes from the **Target registry** (`utilities/targets.py` + `utilities/targets.yaml`), the single source of truth. See `CONTEXT.md` → **Build & deploy** and `docs/adr/0004-target-registry.md`.
 
 ---
 
@@ -9,21 +11,25 @@ This directory contains scripts used to build, tag, push, and deploy Docker imag
 ```
 scripts/
 ├── dev/
-│   ├── build_and_push.sh     # Build + push images using git SHA tags
-│   ├── deploy.sh             # Update dev environment to use pushed images
+│   ├── build_and_push.sh     # Build + push container targets at git-SHA tags
+│   ├── deploy.sh             # Deploy changed targets to the dev environment
 │   └── pipeline.sh           # Orchestrates build, push, deploy for dev
 ├── prod/
-│   ├── build_and_push.sh     # Build + push images using RELEASE_VERSION tags
-│   ├── deploy.sh             # Deploy prod images
+│   ├── build_and_push.sh     # Build + push container targets at RELEASE_VERSION tags
+│   ├── deploy.sh             # Deploy targets to prod
 │   └── release.sh            # Full production release pipeline
 └── util/
+    ├── registry.sh           # Wrapper around the Target registry (registry_query)
+    ├── _build_and_push.sh    # Shared build/push core (container targets)
+    ├── _deploy.sh            # Shared deploy core (packaging seam: image vs zip)
     ├── ecr_login.sh          # Authenticates Docker with AWS ECR
-    ├── find_images.sh        # Enumerates all images in the monorepo
     └── load_env.sh           # Loads shared environment variables
 .env                          # File with deployment specific values
 ```
 
-Requires `.env` file at the repo root containg `AWS_REGION`,  `AWS_ACCOUNT_ID`, `AWS_PROFILE` key value pairs. `AWS_PROFILE` contains the profile name to use with valid credentials for accessing `AWS_ACCOUNT_ID`'s ECR and Lambda services with sufficient privelege   
+Requires a `.env` file at the repo root containing `AWS_REGION`, `AWS_ACCOUNT_ID`, `AWS_PROFILE` key/value pairs. `AWS_PROFILE` names the profile with valid credentials for `AWS_ACCOUNT_ID`'s ECR and Lambda services.
+
+The registry runs via `python3 -m utilities.targets`; the `utilities` package must be importable (`pip install .` from the repo root). If `python3` on PATH lacks it, set `REGISTRY_PY` (or `PYTHON`) to a venv interpreter.
 
 Scripts are enforced to be run from the root of the repo.
 
@@ -42,39 +48,33 @@ This provides:
 ## Running dev pipeline
 
 ```
-scripts/dev/pipeline.sh [--all] [--dry-run]
+scripts/dev/pipeline.sh [--all] [--dry-run] [--base <ref>]
 ```
 
 ### Options
 
 | Flag | Description |
 |------|-------------|
-| `--all` | Forces build and deploy of all images within repo, bypassing git diff with main |
+| `--all` | Build and deploy every target, bypassing change detection |
 | `--dry-run` | Skips build, push, and deployment, logging steps to be taken instead |
+| `--base <ref>` | Git ref to diff against for change detection (default: `main`) |
 
 ### How the dev pipeline works
 
 1. **Load environment + authenticate with ECR**  
    Uses `load_env.sh` and `ecr_login.sh`.
 
-2. **Generate list of all images**  
-   Uses `util/find_images.sh`.
+2. **Detect which targets changed**  
+   Asks the Target registry: `registry_query dirty --base main`. Change-impact is dependency-aware — a change to `utilities/`, root `setup.py`, or `pipeline_runtime/` dirties the stages that depend on them, not just the directory that changed. (`--all` lists the full catalog instead.)
 
-3. **Detect which images changed**  
-   For each image directory, the pipeline compares:
-   ```
-   git diff main..HEAD
-   ```
-   Only changed images are rebuilt.
-
-4. **Build & push changed images**  
-   Tags are of the form:
+3. **Build & push changed container targets**  
+   `dev/build_and_push.sh` builds the container targets (skipping zip targets, which have no image). Tags are of the form:
    ```
    <registry>/dev/<image>:<git_sha>
    ```
 
-5. **Deploy updated images**  
-   The `dev/deploy.sh` script updates Lambda functions, ECS tasks, or other resources to pull the new dev-tagged image.
+4. **Deploy changed targets**  
+   `dev/deploy.sh` updates each deployable target's Lambda, branching on packaging kind: container targets via `--image-uri`, zip targets (the `pipeline/infra/` Lambdas) by zipping the source dir and using `--zip-file`. Non-deployable targets (e.g. `pipeline_runtime`) are skipped.
 
 ---
 
@@ -111,8 +111,8 @@ scripts/prod/release.sh --version <RELEASE_VERSION> [--no-cleanup] [--dry-run]
 2. **Load environment + authenticate**  
    Same shared utility scripts as dev.
 
-3. **Enumerate all images**  
-   Prod always rebuilds **every** image.
+3. **Enumerate all targets**  
+   From the Target registry (`registry_query catalog`). Prod always rebuilds **every** container target and deploys **every** deployable target.
 
 4. **Build & push all images**  
    Tags are of the form:
@@ -140,15 +140,20 @@ scripts/prod/release.sh --version <RELEASE_VERSION> [--no-cleanup] [--dry-run]
 
 # Utilities
 
-## `util/find_images.sh`
-Outputs the canonical list of Docker image directories.  
-Both dev and prod orchestrators use this to iterate through the full set of images.
+## `util/registry.sh`
+Wrapper exposing `registry_query <subcommand>` over the Target registry (`utilities/targets.py`). Used by every orchestrator and core to ask which targets exist, where they live, which are heavy/deployable, and which changed (`catalog` / `dirty`).
+
+## `util/_build_and_push.sh`
+Shared build/push core. Builds and pushes **container** targets (orders `pipeline_runtime` first, passes `BASE_IMAGE` to heavy stages, ensures the ECR repo exists). Skips zip targets.
+
+## `util/_deploy.sh`
+Shared deploy core (`deploy_targets`). Deploys each deployable target at the packaging seam: container → `update-function-code --image-uri`, zip → zip the source dir → `update-function-code --zip-file`.
 
 ## `util/ecr_login.sh`
 Authenticates Docker with AWS ECR and returns the registry URI.
 
 ## `util/load_env.sh`
-Loads shared environment variables (AWS account ID, region, repository name, etc.).  
+Loads shared environment variables (AWS account ID, region, profile, git SHA).  
 Used by all build/deploy scripts.
 
 ---
@@ -159,15 +164,15 @@ Used by all build/deploy scripts.
 | Feature | Behavior |
 |---------|----------|
 | Tag format | `dev/<image>:<git_sha>` |
-| Builds | Only changed images |
-| Deploys | Only rebuilt images |
-| Flags | `--all`, `--dry-run` |
+| Builds | Only changed targets (dependency-aware) |
+| Deploys | Only changed targets (container + zip) |
+| Flags | `--all`, `--dry-run`, `--base <ref>` |
 
 ### Prod pipeline (`prod/release.sh`)
 | Feature | Behavior |
 |---------|----------|
 | Tag format | `prod/<image>:<RELEASE_VERSION>` |
-| Builds | All images, always |
-| Deploys | Entire environment |
+| Builds | All container targets, always |
+| Deploys | All deployable targets (container + zip) |
 | Cleanup | ON by default (removes dev+prod images locally) |
 | Flags | `--version`, `--no-cleanup`, `--dry-run` |

--- a/scripts/dev/deploy.sh
+++ b/scripts/dev/deploy.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# Dev deploy wrapper. Deploys the given targets at the current git-SHA tag via
+# the shared deploy core, which queries the Target registry and branches on
+# packaging kind (container image vs zip).
+#
+# Usage: scripts/dev/deploy.sh <target> [<target>...]
+
 UTIL="$(cd "$(dirname "$0")/../util" && pwd)"
 source "$UTIL/load_env.sh"
 
 if [ -z "$REGISTRY" ]; then
-    echo "REGISTRY not set, assuming manual run"
-    echo "Logging in to ECR..."
-    DEV="$(cd "$(dirname "$0")" && pwd)"
-    UTIL="$DEV/../util"
-
+    echo "REGISTRY not set, logging in to ECR..." >&2
     export REGISTRY=$("$UTIL/ecr_login.sh")
 fi
 
@@ -20,39 +22,13 @@ if [ -z "$DRY_RUN" ]; then
     : "${AWS_PROFILE:?AWS_PROFILE not set}"
 fi
 
-IMAGES=("$@")
-if [ ${#IMAGES[@]} -eq 0 ]; then
-    echo "No images provided to deploy.sh"
+if [ "$#" -eq 0 ]; then
+    echo "No targets provided to deploy.sh"
     exit 1
 fi
 
-# Images that are build-only artifacts (base images, etc.) — pushed to ECR for
-# stage builds to consume, but with no corresponding Lambda function to update.
-BUILD_ONLY_IMAGES=(pipeline_runtime)
+export ENV="dev"
+export TAG="dev-${GIT_SHA}"
 
-is_build_only() {
-    for s in "${BUILD_ONLY_IMAGES[@]}"; do
-        [[ "$s" == "$1" ]] && return 0
-    done
-    return 1
-}
-
-TAG="dev-${GIT_SHA}"
-
-for IMAGE in "${IMAGES[@]}"; do
-    if is_build_only "$IMAGE"; then
-        echo "Skipping deploy for $IMAGE (base image; no Lambda function)"
-        continue
-    fi
-
-    FULL="$REGISTRY/dev/$IMAGE:$TAG"
-
-    if [ -z "$DRY_RUN" ]; then
-        aws --profile "$AWS_PROFILE" lambda update-function-code \
-            --function-name "dev-${IMAGE}" \
-            --image-uri "$FULL"
-        echo "Deployed dev image: $FULL"
-    else
-        echo "[DRY-RUN] Would deploy dev image: $FULL to function ${IMAGE}-dev"
-    fi
-done
+source "$UTIL/_deploy.sh"
+deploy_targets "$@"

--- a/scripts/dev/pipeline.sh
+++ b/scripts/dev/pipeline.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# Dev pipeline: build + push + deploy only the targets that changed vs main
+# (or all of them with --all). The set of targets and the change-impact
+# analysis both come from the Target registry (utilities/targets.py), which
+# knows the real dependency edges — a change to utilities/, setup.py, or
+# pipeline_runtime/ dirties the stages that depend on them, not just the dir
+# that changed.
+#
+# Usage: scripts/dev/pipeline.sh [--all] [--dry-run] [--base <ref>]
+
 # Ensure we are in the repo root
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [ -z "$REPO_ROOT" ] || [ "$(pwd)" != "$REPO_ROOT" ]; then
@@ -10,57 +19,46 @@ fi
 
 DEV="$(cd "$(dirname "$0")" && pwd)"
 UTIL="$DEV/../util"
+source "$UTIL/registry.sh"
 
-# Check for --all flag
 FORCE_ALL=false
-for arg in "$@"; do
-    if [ "$arg" == "--all" ]; then
-        FORCE_ALL=true
-        # Remove the flag from args so it doesn't get passed down
-        set -- "${@//$arg/}"
-    fi
-    if [ "$arg" == "--dry-run" ]; then
-        export DRY_RUN=true
-        # Remove the flag from args so it doesn't get passed down
-        set -- "${@//$arg/}"
-    fi
+BASE_REF="main"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --all)     FORCE_ALL=true; shift ;;
+        --dry-run) export DRY_RUN=true; shift ;;
+        --base)    BASE_REF="$2"; shift 2 ;;
+        *)         echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
 done
 
 source "$UTIL/load_env.sh"
 
-# Login to ECR once
+# Login to ECR once (shared with the build/deploy children via $REGISTRY).
 export REGISTRY=$("$UTIL/ecr_login.sh")
 
-# Detect all images once
-ALL_IMAGES=()
-while IFS= read -r img; do
-    ALL_IMAGES+=("$img")
-done < <("$UTIL/find_images.sh")
-
-if [ ${#ALL_IMAGES[@]} -eq 0 ]; then
-    echo "No Docker images found!"
-    exit 1
+# Determine which targets to (re)build/deploy via the Target registry.
+TARGETS=()
+if [ "$FORCE_ALL" = true ]; then
+    while IFS= read -r name; do
+        [ -n "$name" ] && TARGETS+=("$name")
+    done < <(registry_query catalog | cut -f1)
+else
+    while IFS= read -r name; do
+        [ -n "$name" ] && TARGETS+=("$name")
+    done < <(registry_query dirty --base "$BASE_REF")
 fi
 
-# Determine which images need to be built
-IMAGES_TO_BUILD=()
-for IMAGE in "${ALL_IMAGES[@]}"; do
-    DIR=$(find pipeline -type d -name "$IMAGE" | head -1)
-
-    if [ "$FORCE_ALL" = true ] || ! git diff --quiet main...HEAD -- "$DIR"; then
-        IMAGES_TO_BUILD+=("$IMAGE")
-    else
-        echo "Skipping $IMAGE (no changes compared to main)"
-    fi
-done
-
-if [ ${#IMAGES_TO_BUILD[@]} -eq 0 ]; then
-    echo "No images need to be built or deployed."
+if [ ${#TARGETS[@]} -eq 0 ]; then
+    echo "No targets changed vs $BASE_REF; nothing to build or deploy."
     exit 0
 fi
 
-# Pass only the images that need to be built/deployed
-"$DEV/build_and_push.sh" "${IMAGES_TO_BUILD[@]}"
-"$DEV/deploy.sh" "${IMAGES_TO_BUILD[@]}"
+echo "Targets to build/deploy: ${TARGETS[*]}"
 
-echo "Pipeline complete for images: ${IMAGES_TO_BUILD[*]}"
+# build_and_push builds the container targets (and skips zip); deploy handles
+# every deployable target, packaging zip targets on the fly.
+"$DEV/build_and_push.sh" "${TARGETS[@]}"
+"$DEV/deploy.sh" "${TARGETS[@]}"
+
+echo "Pipeline complete for: ${TARGETS[*]}"

--- a/scripts/prod/deploy.sh
+++ b/scripts/prod/deploy.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# Prod deploy wrapper. Deploys the given targets at the release-version tag via
+# the shared deploy core, which queries the Target registry and branches on
+# packaging kind (container image vs zip).
+#
+# Usage: scripts/prod/deploy.sh <version> <target> [<target>...]
+
 UTIL="$(cd "$(dirname "$0")/../util" && pwd)"
 source "$UTIL/load_env.sh"
 
@@ -12,39 +18,20 @@ if [ -z "$DRY_RUN" ]; then
 fi
 
 RELEASE_VERSION="$1"
-shift
-IMAGES=("$@")
+shift || true
 
-if [ -z "$RELEASE_VERSION" ]; then
-    echo "deploy.sh requires: <version> <image>..."
+if [ -z "$RELEASE_VERSION" ] || [ "$#" -eq 0 ]; then
+    echo "deploy.sh requires: <version> <target>..."
     exit 1
 fi
 
-# Images that are build-only artifacts (base images, etc.) — pushed to ECR for
-# stage builds to consume, but with no corresponding Lambda function to update.
-BUILD_ONLY_IMAGES=(pipeline_runtime)
+if [ -z "$REGISTRY" ]; then
+    echo "REGISTRY not set, logging in to ECR..." >&2
+    export REGISTRY=$("$UTIL/ecr_login.sh")
+fi
 
-is_build_only() {
-    for s in "${BUILD_ONLY_IMAGES[@]}"; do
-        [[ "$s" == "$1" ]] && return 0
-    done
-    return 1
-}
+export ENV="prod"
+export TAG="$RELEASE_VERSION"
 
-for IMAGE in "${IMAGES[@]}"; do
-    if is_build_only "$IMAGE"; then
-        echo "Skipping deploy for $IMAGE (base image; no Lambda function)"
-        continue
-    fi
-
-    FULL="$REGISTRY/prod/$IMAGE:$RELEASE_VERSION"
-
-    if [ -z "$DRY_RUN" ]; then
-        aws --profile "$AWS_PROFILE" lambda update-function-code \
-            --function-name "prod-${IMAGE}" \
-            --image-uri "$FULL"
-        echo "Deployed prod image: $FULL"
-    else
-        echo "[DRY-RUN] Would deploy prod image: $FULL"
-    fi
-done
+source "$UTIL/_deploy.sh"
+deploy_targets "$@"

--- a/scripts/prod/release.sh
+++ b/scripts/prod/release.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# Production release: build + push + deploy every target at an explicit version.
+# The full set of targets comes from the Target registry (utilities/targets.py).
+#
+# Usage: scripts/prod/release.sh --version <RELEASE_VERSION> [--no-cleanup] [--dry-run]
+
 # Ensure we are in the repo root
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [ -z "$REPO_ROOT" ] || [ "$(pwd)" != "$REPO_ROOT" ]; then
@@ -10,7 +15,7 @@ fi
 
 PROD="$(cd "$(dirname "$0")" && pwd)"
 UTIL="$PROD/../util"
-
+source "$UTIL/registry.sh"
 source "$UTIL/load_env.sh"
 
 # -----------------------------
@@ -21,22 +26,10 @@ RELEASE_VERSION=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --no-cleanup)
-            NO_CLEANUP=true
-            shift
-            ;;
-        --version)
-            RELEASE_VERSION="$2"
-            shift 2
-            ;;
-        --dry-run)
-            export DRY_RUN=1
-            shift
-            ;;
-        *)
-            echo "Unknown argument: $1"
-            exit 1
-            ;;
+        --no-cleanup) NO_CLEANUP=true; shift ;;
+        --version)    RELEASE_VERSION="$2"; shift 2 ;;
+        --dry-run)    export DRY_RUN=1; shift ;;
+        *)            echo "Unknown argument: $1"; exit 1 ;;
     esac
 done
 
@@ -46,30 +39,33 @@ if [ -z "$RELEASE_VERSION" ]; then
 fi
 
 # -----------------------------
-# Discover all images
+# Discover all targets (registry is the source of truth)
 # -----------------------------
-IMAGES=()
-while IFS= read -r img; do
-    IMAGES+=("$img")
-done < <("$UTIL/find_images.sh")
+ALL_TARGETS=()
+while IFS= read -r name; do
+    [ -n "$name" ] && ALL_TARGETS+=("$name")
+done < <(registry_query catalog | cut -f1)
 
-if [ ${#IMAGES[@]} -eq 0 ]; then
-    echo "No Docker images found!"
+if [ ${#ALL_TARGETS[@]} -eq 0 ]; then
+    echo "No targets found in the registry!"
     exit 1
 fi
+
+# Container targets only, for local image cleanup at the end.
+CONTAINER_TARGETS=()
+while IFS= read -r name; do
+    [ -n "$name" ] && CONTAINER_TARGETS+=("$name")
+done < <(registry_query catalog | awk -F'\t' '$3=="container"{print $1}')
 
 # Log in to ECR once
 export REGISTRY=$("$UTIL/ecr_login.sh")
 
 # -----------------------------
-# Build and push ALL images
+# Build/push all container targets, deploy all deployable targets
+# (build_and_push skips zip targets; deploy skips non-deployable ones)
 # -----------------------------
-"$PROD/build_and_push.sh" "$RELEASE_VERSION" "${IMAGES[@]}"
-
-# -----------------------------
-# Deploy ALL images
-# -----------------------------
-"$PROD/deploy.sh" "$RELEASE_VERSION" "${IMAGES[@]}"
+"$PROD/build_and_push.sh" "$RELEASE_VERSION" "${ALL_TARGETS[@]}"
+"$PROD/deploy.sh" "$RELEASE_VERSION" "${ALL_TARGETS[@]}"
 
 # -----------------------------
 # Optional cleanup
@@ -78,12 +74,12 @@ if [ "$NO_CLEANUP" = true ] || [ -n "$DRY_RUN" ]; then
     echo "Skipping cleanup (flag: --no-cleanup or DRY_RUN mode)"
 else
     echo "Cleaning up local prod images..."
-    for IMAGE in "${IMAGES[@]}"; do
+    for IMAGE in "${CONTAINER_TARGETS[@]}"; do
         docker rmi "$REGISTRY/prod/$IMAGE:$RELEASE_VERSION" || true
     done
 
     echo "Cleaning up local dev images..."
-    for IMAGE in "${IMAGES[@]}"; do
+    for IMAGE in "${CONTAINER_TARGETS[@]}"; do
         # Remove *all* dev-tagged images for this image
         docker images "$REGISTRY/dev/$IMAGE" -q | xargs -r docker rmi || true
     done

--- a/scripts/util/_build_and_push.sh
+++ b/scripts/util/_build_and_push.sh
@@ -5,17 +5,25 @@ set -eo pipefail
 # scripts/prod/build_and_push.sh, which set ENV, RELEASE_VERSION, and REGISTRY
 # before exec'ing into this script.
 #
+# Builds and pushes CONTAINER targets only — zip targets (the pipeline/infra
+# Lambdas) have no image and are packaged at deploy time. Which targets exist,
+# where they live, and which are heavy all come from the Target registry
+# (utilities/targets.py); there are no hardcoded lists here.
+#
 # Responsibilities:
-#   - Pass BASE_REGISTRY / BASE_TAG build args to heavy stages so they can
-#     FROM the matching pipeline_runtime tag.
+#   - Pass the BASE_IMAGE build arg to heavy stages so they FROM the matching
+#     pipeline_runtime tag.
 #   - Order pipeline_runtime first when it's part of the same invocation, so
-#     stages can pull it.
-#   - When pipeline_runtime is not in this invocation, verify the expected
-#     tag exists in ECR before letting any heavy stage build proceed.
+#     stages can FROM it.
+#   - When pipeline_runtime is not in this invocation, verify the expected tag
+#     exists in ECR before letting any heavy stage build proceed.
 
 : "${ENV:?ENV must be set by the wrapper (dev or prod)}"
 : "${RELEASE_VERSION:?RELEASE_VERSION must be set by the wrapper}"
 : "${REGISTRY:?REGISTRY must be set by the wrapper}"
+
+UTIL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$UTIL/registry.sh"
 
 IMAGES=("$@")
 if [ ${#IMAGES[@]} -eq 0 ]; then
@@ -23,38 +31,38 @@ if [ ${#IMAGES[@]} -eq 0 ]; then
   exit 1
 fi
 
-# Stages whose Dockerfiles FROM pipeline_runtime. Update this list when adding
-# a new heavy stage. Lightweight stages (pipeline_init, unifier) are NOT here
-# and build straight on top of the AWS Lambda Python base image.
-HEAVY_STAGES=(bad_pass xover daily_files oer finalizer indicators simple_grids enso)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-is_heavy_stage() {
-  local name="$1"
-  for s in "${HEAVY_STAGES[@]}"; do
-    [[ "$s" == "$name" ]] && return 0
-  done
-  return 1
-}
+# Snapshot the catalog once; look fields up with awk (bash 3.2-safe — no
+# associative arrays). Columns: 1=name 2=path 3=packaging 4=heavy 5=deployable.
+CATALOG="$(mktemp)"
+trap 'rm -f "$CATALOG"' EXIT
+registry_query catalog > "$CATALOG"
+
+tfield()       { awk -F'\t' -v n="$1" -v c="$2" '$1==n{print $c}' "$CATALOG"; }
+is_heavy()     { [ "$(tfield "$1" 4)" = "true" ]; }
+packaging_of() { tfield "$1" 3; }
+path_of()      { tfield "$1" 2; }
 
 # Sort: pipeline_runtime first if requested, so its tag exists in the local
 # Docker cache before any stage tries to FROM it.
 SORTED=()
 runtime_in_list=0
 for IMAGE in "${IMAGES[@]}"; do
-  if [[ "$IMAGE" == "pipeline_runtime" ]]; then
+  if [ "$IMAGE" = "pipeline_runtime" ]; then
     SORTED+=("$IMAGE")
     runtime_in_list=1
   fi
 done
 for IMAGE in "${IMAGES[@]}"; do
-  [[ "$IMAGE" != "pipeline_runtime" ]] && SORTED+=("$IMAGE")
+  [ "$IMAGE" != "pipeline_runtime" ] && SORTED+=("$IMAGE")
 done
 
 # Precondition: heavy stages need a matching pipeline_runtime tag to FROM. If
 # the runtime isn't being (re)built in this invocation, verify the tag exists.
 if [ "$runtime_in_list" -eq 0 ]; then
   for IMAGE in "${IMAGES[@]}"; do
-    if is_heavy_stage "$IMAGE"; then
+    if is_heavy "$IMAGE"; then
       RUNTIME_REPO="$ENV/pipeline_runtime"
       if ! aws ecr describe-images \
             --repository-name "$RUNTIME_REPO" \
@@ -71,15 +79,18 @@ if [ "$runtime_in_list" -eq 0 ]; then
   done
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-
 for IMAGE in "${SORTED[@]}"; do
-  DIR=$(find "$REPO_ROOT/pipeline" -type d -name "$IMAGE" | head -1)
-  if [ -z "$DIR" ]; then
-    echo "Error: cannot find directory for image '$IMAGE' under pipeline/"
+  PKG="$(packaging_of "$IMAGE")"
+  if [ -z "$PKG" ]; then
+    echo "Error: unknown target '$IMAGE' (not in the Target registry)"
     exit 1
   fi
+  if [ "$PKG" != "container" ]; then
+    echo "Skipping $IMAGE (packaging=$PKG; packaged at deploy time, not built)"
+    continue
+  fi
 
+  DIR="$REPO_ROOT/$(path_of "$IMAGE")"
   FULL="$REGISTRY/$ENV/$IMAGE:$RELEASE_VERSION"
   REPO_NAME="$ENV/$IMAGE"
 
@@ -89,7 +100,7 @@ for IMAGE in "${SORTED[@]}"; do
     --build-arg "RELEASE_VERSION=$RELEASE_VERSION"
   )
 
-  if is_heavy_stage "$IMAGE"; then
+  if is_heavy "$IMAGE"; then
     BUILD_ARGS+=(
       --build-arg "BASE_IMAGE=$REGISTRY/$ENV/pipeline_runtime:$RELEASE_VERSION"
     )

--- a/scripts/util/_deploy.sh
+++ b/scripts/util/_deploy.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Shared deploy core. The dev/prod wrappers set ENV, TAG, and REGISTRY, then
+# source this file and call:  deploy_targets <name>...
+#
+# Deploys each DEPLOYABLE target via the Target registry, branching on packaging
+# kind at the packaging seam:
+#   container -> aws lambda update-function-code --image-uri <registry>/<repo>:<TAG>
+#   zip       -> zip the source dir and update-function-code --zip-file
+# Non-deployable targets (e.g. the pipeline_runtime base image) are skipped.
+
+: "${ENV:?ENV must be set by the wrapper}"
+: "${TAG:?TAG must be set by the wrapper}"
+
+_DEPLOY_UTIL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_DEPLOY_UTIL/registry.sh"
+
+# _tfield <catalog> <name> <col>  (cols: 1=name 2=path 3=packaging 4=heavy
+#                                   5=deployable 6=ecr_repo 7=function)
+_tfield() { awk -F'\t' -v n="$2" -v c="$3" '$1==n{print $c}' "$1"; }
+
+deploy_targets() {
+  if [ "$#" -eq 0 ]; then
+    echo "deploy_targets: no targets given" >&2
+    return 1
+  fi
+
+  local repo_root catalog
+  repo_root="$(git rev-parse --show-toplevel)"
+  catalog="$(mktemp)"
+  registry_query catalog --stage "$ENV" > "$catalog"
+
+  local IMAGE pkg deployable fn ecr dir uri zipfile rc=0
+  for IMAGE in "$@"; do
+    pkg="$(_tfield "$catalog" "$IMAGE" 3)"
+    if [ -z "$pkg" ]; then
+      echo "Error: unknown target '$IMAGE' (not in the Target registry)" >&2
+      rc=1
+      break
+    fi
+
+    deployable="$(_tfield "$catalog" "$IMAGE" 5)"
+    if [ "$deployable" != "true" ]; then
+      echo "Skipping $IMAGE (not deployable; e.g. base image)"
+      continue
+    fi
+
+    fn="$(_tfield "$catalog" "$IMAGE" 7)"
+
+    case "$pkg" in
+      container)
+        ecr="$(_tfield "$catalog" "$IMAGE" 6)"
+        uri="$REGISTRY/$ecr:$TAG"
+        if [ -z "$DRY_RUN" ]; then
+          aws --profile "$AWS_PROFILE" lambda update-function-code \
+            --function-name "$fn" --image-uri "$uri"
+          echo "Deployed $fn <- $uri"
+        else
+          echo "[DRY-RUN] Would deploy $fn <- $uri"
+        fi
+        ;;
+      zip)
+        dir="$repo_root/$(_tfield "$catalog" "$IMAGE" 2)"
+        zipfile="$(mktemp -u).zip"
+        if [ -z "$DRY_RUN" ]; then
+          ( cd "$dir" && zip -r -X "$zipfile" . \
+              -x 'README.md' 'tests/*' '*/__pycache__/*' '__pycache__/*' '*.pyc' \
+              >/dev/null )
+          aws --profile "$AWS_PROFILE" lambda update-function-code \
+            --function-name "$fn" --zip-file "fileb://$zipfile"
+          rm -f "$zipfile"
+          echo "Deployed $fn <- $dir (zip)"
+        else
+          echo "[DRY-RUN] Would zip $dir and deploy $fn"
+        fi
+        ;;
+      *)
+        echo "Error: unknown packaging '$pkg' for $IMAGE" >&2
+        rc=1
+        break
+        ;;
+    esac
+  done
+
+  rm -f "$catalog"
+  return "$rc"
+}

--- a/scripts/util/find_images.sh
+++ b/scripts/util/find_images.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -eo pipefail
-
-find pipeline -name Dockerfile -print0 | while IFS= read -r -d '' file; do
-    dirname "$file" | xargs basename
-done

--- a/scripts/util/registry.sh
+++ b/scripts/util/registry.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Thin wrapper around the Target registry (utilities/targets.py) — the single
+# source of truth for what the build/deploy scripts manage. Source this file
+# and call `registry_query <subcommand> [args...]`, e.g.
+#
+#   registry_query catalog --stage dev   # TSV: name path packaging heavy deployable ecr_repo function
+#   registry_query dirty --base main     # names of targets changed vs a git ref
+#
+# Requires the `utilities` package importable by the chosen interpreter
+# (`pip install .` from the repo root). If `python3` on PATH does not have it,
+# point at a venv via PYTHON or REGISTRY_PY, e.g. REGISTRY_PY=./.venv/bin/python.
+
+: "${REGISTRY_PY:=${PYTHON:-python3}}"
+
+registry_query() {
+    "$REGISTRY_PY" -m utilities.targets "$@"
+}

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,5 @@ setup(
     packages=["utilities"],
     install_requires=["s3fs", "boto3", "pyyaml"],
     include_package_data=True,
-    package_data={"utilities": ["products.yaml", "sources/*.yaml"]},
+    package_data={"utilities": ["products.yaml", "sources/*.yaml", "targets.yaml"]},
 )

--- a/utilities/targets.py
+++ b/utilities/targets.py
@@ -1,0 +1,244 @@
+"""Target registry: the single source of truth for the build/deploy scripts.
+
+A *Target* is anything the build/deploy scripts manage — a buildable image
+and/or a deployable Lambda. Existence and packaging kind are derived from the
+filesystem; the ``heavy`` / ``deployable`` facts are declared in ``targets.yaml``.
+See CONTEXT.md -> Build & deploy and docs/adr/0004-target-registry.md.
+
+Callers (the bash scripts) use the CLI:
+
+    python -m utilities.targets catalog [--stage dev]   # TSV catalog
+    python -m utilities.targets dirty --base main       # names to rebuild
+
+The pure functions ``targets()`` and ``dirty()`` are the test surface.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+
+class Packaging(str, Enum):
+    CONTAINER = "container"
+    ZIP = "zip"
+
+
+# Repo-relative paths every container target (except pipeline_runtime) depends
+# on at build time (each stage Dockerfile does `COPY utilities/` + `pip install .`).
+# If the shared package or build metadata moves (e.g. the planned
+# utilities/ -> src/shared/), update this one constant.
+_SHARED_BUILD_PATHS = ("utilities", "setup.py")
+
+_RUNTIME_NAME = "pipeline_runtime"
+_MANIFEST_NAME = "targets.yaml"
+
+
+@dataclass(frozen=True)
+class Target:
+    name: str
+    path: Path  # repo-relative dir holding the Dockerfile / app.py
+    packaging: Packaging
+    heavy: bool
+    deployable: bool
+
+    def ecr_repo(self, stage: str) -> str:
+        if self.packaging is not Packaging.CONTAINER:
+            raise ValueError(f"{self.name!r} is not a container target; it has no ECR repo")
+        return f"{stage}/{self.name}"
+
+    def function_name(self, stage: str) -> str:
+        if not self.deployable:
+            raise ValueError(f"{self.name!r} is not deployable; it has no Lambda function")
+        return f"{stage}-{self.name}"
+
+
+def _find_repo_root() -> Path:
+    """Locate the repo root from either the module location (editable install)
+    or the cwd (the scripts enforce running from the repo root)."""
+    for start in (Path(__file__).resolve(), Path.cwd().resolve()):
+        for d in (start, *start.parents):
+            if (d / "setup.py").is_file() and (d / "pipeline").is_dir():
+                return d
+    raise RuntimeError(
+        "Target registry: could not locate the repo root (need setup.py + pipeline/)."
+    )
+
+
+def _discover(repo_root: Path) -> dict[str, tuple[Path, Packaging]]:
+    """name -> (repo-relative path, packaging), derived from the filesystem."""
+    found: dict[str, tuple[Path, Packaging]] = {}
+    pipeline = repo_root / "pipeline"
+
+    for dockerfile in pipeline.rglob("Dockerfile"):
+        d = dockerfile.parent
+        found[d.name] = (d.relative_to(repo_root), Packaging.CONTAINER)
+
+    for app in (pipeline / "infra").glob("*/app.py"):
+        d = app.parent
+        if (d / "Dockerfile").is_file():
+            continue  # already captured as a container target
+        found[d.name] = (d.relative_to(repo_root), Packaging.ZIP)
+
+    return found
+
+
+def _load_declared() -> dict[str, dict]:
+    manifest = Path(__file__).resolve().parent / _MANIFEST_NAME
+    with open(manifest) as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("targets") or {}
+
+
+_CACHE: list[Target] | None = None
+
+
+def clear_cache() -> None:
+    """Drop the memoized catalog (tests)."""
+    global _CACHE
+    _CACHE = None
+
+
+def targets() -> list[Target]:
+    """The full catalog, sorted by name.
+
+    Raises if ``targets.yaml`` and the filesystem disagree, so every caller is
+    protected from drift, not just the consistency test.
+    """
+    global _CACHE
+    if _CACHE is not None:
+        return _CACHE
+
+    repo_root = _find_repo_root()
+    discovered = _discover(repo_root)
+    declared = _load_declared()
+
+    fs_names, yaml_names = set(discovered), set(declared)
+    if fs_names != yaml_names:
+        lines = ["Target registry: targets.yaml is out of sync with the filesystem."]
+        if fs_names - yaml_names:
+            lines.append(f"  on disk but not declared: {sorted(fs_names - yaml_names)}")
+        if yaml_names - fs_names:
+            lines.append(f"  declared but not on disk: {sorted(yaml_names - fs_names)}")
+        raise RuntimeError("\n".join(lines))
+
+    result: list[Target] = []
+    for name, (path, packaging) in sorted(discovered.items()):
+        facts = declared.get(name) or {}
+        heavy = bool(facts.get("heavy", False))
+        deployable = bool(facts.get("deployable", True))
+        if packaging is Packaging.ZIP and heavy:
+            raise RuntimeError(f"Target registry: zip target {name!r} cannot be heavy.")
+        result.append(Target(name, path, packaging, heavy, deployable))
+
+    _CACHE = result
+    return result
+
+
+def get(name: str) -> Target:
+    for t in targets():
+        if t.name == name:
+            return t
+    raise KeyError(name)
+
+
+def _under(path: str, root: str) -> bool:
+    p = path.replace("\\", "/").strip("/")
+    r = root.replace("\\", "/").strip("/")
+    return p == r or p.startswith(r + "/")
+
+
+def dirty(changed_paths: Iterable[str]) -> list[Target]:
+    """The Targets that must be rebuilt/redeployed for a set of changed
+    repo-relative paths. Pure over (changed_paths, catalog).
+
+    Edges (see CONTEXT.md -> Change-impact):
+      - own dir changed                     -> any target
+      - utilities/ or setup.py changed      -> every container target except pipeline_runtime
+      - pipeline_runtime/ changed           -> every heavy target
+    """
+    changed = [c for c in changed_paths if c and c.strip()]
+
+    shared_changed = any(
+        any(_under(c, sp) for sp in _SHARED_BUILD_PATHS) for c in changed
+    )
+    runtime_path = str(get(_RUNTIME_NAME).path)
+    runtime_changed = any(_under(c, runtime_path) for c in changed)
+
+    result: list[Target] = []
+    for t in targets():
+        own = any(_under(c, str(t.path)) for c in changed)
+        shared_edge = (
+            t.packaging is Packaging.CONTAINER
+            and t.name != _RUNTIME_NAME
+            and shared_changed
+        )
+        runtime_edge = t.heavy and runtime_changed
+        if own or shared_edge or runtime_edge:
+            result.append(t)
+    return result
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────────
+
+def _cmd_catalog(stage: str | None) -> int:
+    for t in targets():
+        ecr = t.ecr_repo(stage) if (stage and t.packaging is Packaging.CONTAINER) else ""
+        fn = t.function_name(stage) if (stage and t.deployable) else ""
+        print(
+            "\t".join(
+                [
+                    t.name,
+                    str(t.path),
+                    t.packaging.value,
+                    "true" if t.heavy else "false",
+                    "true" if t.deployable else "false",
+                    ecr,
+                    fn,
+                ]
+            )
+        )
+    return 0
+
+
+def _cmd_dirty(base: str) -> int:
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    for t in dirty(proc.stdout.splitlines()):
+        print(t.name)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="python -m utilities.targets")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    cat = sub.add_parser("catalog", help="emit the TSV catalog of all targets")
+    cat.add_argument("--stage", help="fill ecr_repo/function columns for this stage")
+
+    dty = sub.add_parser("dirty", help="emit names of targets changed vs a git ref")
+    dty.add_argument("--base", default="main", help="base git ref (default: main)")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "catalog":
+        return _cmd_catalog(args.stage)
+    if args.cmd == "dirty":
+        return _cmd_dirty(args.base)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utilities/targets.py
+++ b/utilities/targets.py
@@ -160,7 +160,9 @@ def dirty(changed_paths: Iterable[str]) -> list[Target]:
     Edges (see CONTEXT.md -> Change-impact):
       - own dir changed                     -> any target
       - utilities/ or setup.py changed      -> every container target except pipeline_runtime
-      - pipeline_runtime/ changed           -> every heavy target
+      - pipeline_runtime/ changed           -> every heavy target + pipeline_runtime itself
+      - any heavy target in result          -> pipeline_runtime (must exist in ECR at the
+                                              target SHA even when its content is unchanged)
     """
     changed = [c for c in changed_paths if c and c.strip()]
 
@@ -181,6 +183,15 @@ def dirty(changed_paths: Iterable[str]) -> list[Target]:
         runtime_edge = t.heavy and runtime_changed
         if own or shared_edge or runtime_edge:
             result.append(t)
+
+    # If any heavy stage needs to be built, pipeline_runtime must also be
+    # available at the target SHA — the SHA-tagged ECR image won't exist even
+    # when its own content is unchanged.
+    if any(t.heavy for t in result):
+        runtime = get(_RUNTIME_NAME)
+        if runtime not in result:
+            result.insert(0, runtime)
+
     return result
 
 

--- a/utilities/targets.yaml
+++ b/utilities/targets.yaml
@@ -1,0 +1,37 @@
+# Declared build/deploy facts per Target. See CONTEXT.md -> Build & deploy and
+# docs/adr/0004-target-registry.md.
+#
+# Existence and packaging kind are DERIVED from the filesystem (a Dockerfile =>
+# container, an infra app.py => zip). This file declares only the two facts that
+# can't be reliably derived:
+#   heavy      - container image FROMs pipeline_runtime via the BASE_IMAGE
+#                override (container targets only; guarded by a test against the
+#                Dockerfile's actual base parameterization)
+#   deployable - target maps to a ${stage}-${name} Lambda the deploy step updates
+#
+# Defaults: heavy=false, deployable=true. Every target MUST be listed so the
+# consistency test can pin this manifest to the filesystem. This file is
+# path-less so it survives directory moves (e.g. the planned pipeline/ -> src/).
+targets:
+  # ── container — heavy stages (FROM pipeline_runtime) ──────────────────
+  bad_pass:      {heavy: true}
+  daily_files:   {heavy: true}
+  finalizer:     {heavy: true}
+  oer:           {heavy: true}
+  xover:         {heavy: true}
+  enso:          {heavy: true}
+  indicators:    {heavy: true}
+  simple_grids:  {heavy: true}
+
+  # ── container — lightweight stages (literal FROM lambda/python) ───────
+  pipeline_init: {}
+  unifier:       {}
+
+  # ── container — base image (built + pushed, never deployed) ───────────
+  pipeline_runtime: {deployable: false}
+
+  # ── zip — infra Lambdas ───────────────────────────────────────────────
+  failure_handling: {}
+  podaac_auth:      {}
+  rewrite_manifest: {}
+  set_sg_jobs:      {}

--- a/utilities/tests/test_targets.py
+++ b/utilities/tests/test_targets.py
@@ -92,18 +92,26 @@ class TestChangeImpact(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(self._names([]), set())
 
-    def test_own_dir(self):
-        oer = reg.get("oer").path
-        self.assertEqual(self._names([f"{oer}/processing.py"]), {"oer"})
+    def test_own_dir_light_container(self):
+        pi = reg.get("pipeline_init").path
+        self.assertEqual(self._names([f"{pi}/handler.py"]), {"pipeline_init"})
 
-    def test_shared_utilities_dirties_all_containers_except_runtime(self):
+    def test_heavy_own_dir_includes_runtime(self):
+        # Changing a heavy stage's own dir triggers a build; pipeline_runtime must
+        # also be built so the SHA-tagged ECR image exists, even if its content
+        # hasn't changed.
+        oer = reg.get("oer").path
+        self.assertEqual(self._names([f"{oer}/processing.py"]), {"oer", "pipeline_runtime"})
+
+    def test_shared_utilities_dirties_all_containers(self):
+        # Heavy stages are dirty → pipeline_runtime is added via the build-dep edge.
         self.assertEqual(
             self._names(["utilities/aws_utils.py"]),
-            ALL_CONTAINER - BASE_IMAGE,
+            ALL_CONTAINER,
         )
 
-    def test_setup_py_dirties_all_containers_except_runtime(self):
-        self.assertEqual(self._names(["setup.py"]), ALL_CONTAINER - BASE_IMAGE)
+    def test_setup_py_dirties_all_containers(self):
+        self.assertEqual(self._names(["setup.py"]), ALL_CONTAINER)
 
     def test_runtime_change_dirties_heavy_and_runtime_itself(self):
         rt = reg.get("pipeline_runtime").path
@@ -123,7 +131,7 @@ class TestChangeImpact(unittest.TestCase):
         oer = reg.get("oer").path
         self.assertEqual(
             self._names([f"{oer}/x.py", "utilities/aws_utils.py"]),
-            ALL_CONTAINER - BASE_IMAGE,
+            ALL_CONTAINER,
         )
 
 

--- a/utilities/tests/test_targets.py
+++ b/utilities/tests/test_targets.py
@@ -1,0 +1,131 @@
+import unittest
+from pathlib import Path
+
+from utilities import targets as reg
+from utilities.targets import Packaging
+
+
+# Expected catalog, kept here as an independent assertion of intent (the module
+# derives this from the filesystem; this pins what we expect to find).
+HEAVY = {"bad_pass", "daily_files", "finalizer", "oer", "xover", "enso", "indicators", "simple_grids"}
+LIGHT_CONTAINER = {"pipeline_init", "unifier"}
+BASE_IMAGE = {"pipeline_runtime"}
+ZIP = {"failure_handling", "podaac_auth", "rewrite_manifest", "set_sg_jobs"}
+
+ALL_CONTAINER = HEAVY | LIGHT_CONTAINER | BASE_IMAGE
+ALL_NAMES = ALL_CONTAINER | ZIP
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestCatalogConsistency(unittest.TestCase):
+    def setUp(self):
+        reg.clear_cache()
+
+    def test_manifest_matches_filesystem(self):
+        # targets() raises if targets.yaml and the filesystem disagree.
+        names = {t.name for t in reg.targets()}
+        self.assertEqual(names, ALL_NAMES)
+
+    def test_packaging_is_derived(self):
+        by_name = {t.name: t for t in reg.targets()}
+        for name in ALL_CONTAINER:
+            self.assertIs(by_name[name].packaging, Packaging.CONTAINER, name)
+        for name in ZIP:
+            self.assertIs(by_name[name].packaging, Packaging.ZIP, name)
+
+    def test_paths_resolve(self):
+        for t in reg.targets():
+            d = REPO_ROOT / t.path
+            self.assertTrue(d.is_dir(), f"{t.name}: {d} is not a dir")
+            marker = "Dockerfile" if t.packaging is Packaging.CONTAINER else "app.py"
+            self.assertTrue((d / marker).is_file(), f"{t.name}: missing {marker}")
+
+    def test_deployable(self):
+        by_name = {t.name: t for t in reg.targets()}
+        self.assertFalse(by_name["pipeline_runtime"].deployable)
+        for name in ALL_NAMES - {"pipeline_runtime"}:
+            self.assertTrue(by_name[name].deployable, name)
+
+    def test_heavy_matches_base_image_parameterization(self):
+        # The brittle-grep contract, guarded: heavy <=> the Dockerfile
+        # parameterizes its base via ${BASE_IMAGE}.
+        for t in reg.targets():
+            if t.packaging is not Packaging.CONTAINER:
+                self.assertFalse(t.heavy, f"{t.name}: zip target marked heavy")
+                continue
+            text = (REPO_ROOT / t.path / "Dockerfile").read_text()
+            parameterized = "${BASE_IMAGE}" in text
+            self.assertEqual(
+                t.heavy, parameterized,
+                f"{t.name}: heavy={t.heavy} but Dockerfile parameterized={parameterized}",
+            )
+
+
+class TestNamingHelpers(unittest.TestCase):
+    def setUp(self):
+        reg.clear_cache()
+
+    def test_ecr_repo(self):
+        self.assertEqual(reg.get("oer").ecr_repo("dev"), "dev/oer")
+
+    def test_function_name(self):
+        self.assertEqual(reg.get("oer").function_name("prod"), "prod-oer")
+        self.assertEqual(reg.get("failure_handling").function_name("dev"), "dev-failure_handling")
+
+    def test_ecr_repo_rejects_zip(self):
+        with self.assertRaises(ValueError):
+            reg.get("failure_handling").ecr_repo("dev")
+
+    def test_function_name_rejects_non_deployable(self):
+        with self.assertRaises(ValueError):
+            reg.get("pipeline_runtime").function_name("dev")
+
+
+class TestChangeImpact(unittest.TestCase):
+    def setUp(self):
+        reg.clear_cache()
+
+    def _names(self, changed):
+        return {t.name for t in reg.dirty(changed)}
+
+    def test_empty(self):
+        self.assertEqual(self._names([]), set())
+
+    def test_own_dir(self):
+        oer = reg.get("oer").path
+        self.assertEqual(self._names([f"{oer}/processing.py"]), {"oer"})
+
+    def test_shared_utilities_dirties_all_containers_except_runtime(self):
+        self.assertEqual(
+            self._names(["utilities/aws_utils.py"]),
+            ALL_CONTAINER - BASE_IMAGE,
+        )
+
+    def test_setup_py_dirties_all_containers_except_runtime(self):
+        self.assertEqual(self._names(["setup.py"]), ALL_CONTAINER - BASE_IMAGE)
+
+    def test_runtime_change_dirties_heavy_and_runtime_itself(self):
+        rt = reg.get("pipeline_runtime").path
+        self.assertEqual(
+            self._names([f"{rt}/requirements.txt"]),
+            HEAVY | BASE_IMAGE,
+        )
+
+    def test_zip_is_self_contained(self):
+        fh = reg.get("failure_handling").path
+        self.assertEqual(self._names([f"{fh}/app.py"]), {"failure_handling"})
+
+    def test_shared_change_does_not_dirty_zip(self):
+        self.assertNotIn("failure_handling", self._names(["utilities/aws_utils.py"]))
+
+    def test_combined(self):
+        oer = reg.get("oer").path
+        self.assertEqual(
+            self._names([f"{oer}/x.py", "utilities/aws_utils.py"]),
+            ALL_CONTAINER - BASE_IMAGE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Introduces `utilities/targets.py` and `utilities/targets.yaml` as a central target registry replacing scattered hardcoded arrays (`HEAVY_STAGES`, `BUILD_ONLY_IMAGES`) and `find`-based lookups across build/deploy scripts
- Adds change-impact logic (`dirty(changed_paths)`) that correctly propagates rebuilds through shared dependencies (`utilities/`, `setup.py`, `pipeline_runtime/`) so heavy stages are no longer silently skipped in the dev loop
- Wires infra Lambdas (`failure_handling`, `podaac_auth`, `rewrite_manifest`, `set_sg_jobs`) into the deploy path for the first time via a packaging seam (`container` vs `zip`)

## Test plan

- [x] `python -m pytest utilities/tests/` passes (covers consistency guard, change-impact edges, packaging derivation, naming helpers)
- [x] `python -m utilities.targets` returns the expected catalog for the current filesystem
- [x] Dev loop (`scripts/dev/pipeline.sh`) correctly marks heavy stages dirty when only `utilities/` changes
- [x] Infra Lambdas deploy successfully via the updated deploy script

Closes #31 