### PR TITLE
Extend high-latitude (S3B) support: bad_pass, finalizer, simple_grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subtracts a per-source `intermission_bias` before the fit, disables the 0.3 m
   `ssh_max_error` gate, and uses a centered crossover-fetch window. Self-crossover
   output (S6/GSFC) is unchanged.
+- Reference-crossover support in the `bad_pass` stage: dispatches self vs reference from
+  `product_type` and adds a reference load path (unstacked `dssh = ssh1 - ssh2`, centered
+  window) so `high_latitude` sources no longer error. Self-crossover flagging is unchanged.
+- Intermission-bias absolute correction in the `finalizer`: for `high_latitude` sources it
+  subtracts the per-source `intermission_bias` from `ssha`/`ssha_smoothed`, tying the level
+  to the reference datum (idempotent via `intermission_bias_applied`). Adds the S3B
+  `finalizer` config. No-op for reference sources.
+- High-latitude simple grids: registers the `simple_grid_high_latitude` product so the
+  `simple_grids` stage runs on `high_latitude` sources (output `_alt_hilat_simple_grid_`).
+- Flagged bad-pass counts in the `run_summary` notification, reported within the
+  along-track section.
 - Per-source `ground_speed` and `intermission_bias` in the `common` section of source
   configs — one canonical value per source, shared by OER (knot placement, bias
   removal) and daily-file smoothing.

--- a/pipeline/daily_file_gen/bad_pass/README.md
+++ b/pipeline/daily_file_gen/bad_pass/README.md
@@ -4,10 +4,31 @@ Identifies satellite passes with anomalous crossover residuals and writes the fl
 
 ## How it works
 
+bad_pass handles two crossover types, dispatched from the source's
+`common.product_type` (the same 1:1 mapping documented for OER/xover):
+
+| `product_type`   | `crossover_type` | bad_pass path                                   |
+| ---------------- | ---------------- | ----------------------------------------------- |
+| `reference`      | `self`           | self-stacked (sign-flipped), backward window    |
+| `high_latitude`  | `reference`      | fixed-reference (no sign flip), centered window  |
+
 For each processing date, the Lambda:
 
-1. **Gathers crossover files** from a sliding window (10 days back + 1 day pad on each side) under `s3://{bucket}/crossovers/p2/{source}/{year}/`.
-2. **Loads crossover data** (cycle, pass, time, SSH) from the netCDF files and computes SSH differences (`ssh1 - ssh2`) for every crossover point.
+1. **Gathers crossover files** under `s3://{bucket}/crossovers/p2/{source}/{year}/`.
+   The self path uses a sliding backward window (10 days back + 1 day pad); the
+   reference path uses a small **centered** window (`± reference_window_size`
+   days), because reference xover files are keyed by the high-lat crossover time
+   and are self-contained per day.
+2. **Loads crossover data** (cycle, pass, time, SSH) from the netCDF files and
+   computes SSH differences per crossover point:
+   - **self**: each pair is a second observation of the *same* satellite, so the
+     orbit error is shared — each pair contributes twice with opposite sign
+     (`dssh = concat([ssh1 - ssh2, -(ssh1 - ssh2)])`), keyed by both trackids.
+   - **reference**: side 2 (`ssh2`) is the fixed reference-mission truth, not a
+     second observation, so there is **no** sign-flipped stacking — each crossover
+     contributes a single `dssh = ssh1 - ssh2` at the high-lat time, keyed by the
+     high-lat trackid only. The reference schema has no `time2`/`cycle2`; only the
+     high-lat-side vars are read.
 3. **Flags bad passes** by grouping crossover points by track ID (`cycle * 10000 + pass`) and checking two thresholds:
    - **Mean**: If `n > 15` points and `|mean(dssh)| > 0.1` m
    - **RMS**: If `n > 25` points and `std(dssh) > 0.27` m
@@ -22,6 +43,8 @@ bad_pass/
 ├── app.py                        # Lambda handler
 ├── bad_passes/
 │   ├── bad_pass_flag.py          # XoverProcessor — core logic
+│   ├── config/
+│   │   └── source_config.py      # BadPassConfig — product_type dispatch + reference window
 │   └── bad_pass_list.csv         # Static list of known bad passes
 ├── tests/
 │   └── test_bad_pass_flag.py     # Unit tests

--- a/pipeline/daily_file_gen/bad_pass/bad_passes/bad_pass_flag.py
+++ b/pipeline/daily_file_gen/bad_pass/bad_passes/bad_pass_flag.py
@@ -7,8 +7,19 @@ from typing import Dict, Iterable, List
 import netCDF4 as nc
 import numpy as np
 
+from bad_passes.config.source_config import get_source_config
 from utilities.aws_utils import aws_manager
 from utilities.pipeline_layout import bad_pass_key, crossover_key, s3_uri
+
+# product_type ↔ crossover_type ↔ bad_pass path (documented 1:1; mirrors the OER
+# stage's _CROSSOVER_TYPE_BY_PRODUCT_TYPE). A reference mission
+# (product_type=reference) crosses against itself → "self" stacking; a
+# high_latitude source crosses against the finalized reference mission →
+# "reference" fixed-truth (no sign flip).
+_CROSSOVER_TYPE_BY_PRODUCT_TYPE = {
+    "reference": "self",
+    "high_latitude": "reference",
+}
 
 
 class XoverProcessor:
@@ -24,10 +35,21 @@ class XoverProcessor:
     def __init__(self, source: str, date: datetime):
         self.source = source
         self.date = date
+        self.config = get_source_config(source)
+        self.crossover_type = _CROSSOVER_TYPE_BY_PRODUCT_TYPE[self.config.product_type]
         self.windowlen = 10
         self.windowpad = 1
-        self.window_start = date - timedelta(days=self.windowlen) - timedelta(days=self.windowpad)
-        self.window_end = date + timedelta(days=self.windowpad)
+        if self.crossover_type == "reference":
+            # Reference xover files are keyed by the high-lat crossover time and
+            # are self-contained per day, so a small *centered* window covers the
+            # neighboring days needed by the time-pad in identify_bad_passes.
+            n = self.config.reference_window_size
+            self.window_start = date - timedelta(days=n)
+            self.window_end = date + timedelta(days=n)
+        else:
+            # self xover files "look forward" in time → backward-looking window.
+            self.window_start = date - timedelta(days=self.windowlen) - timedelta(days=self.windowpad)
+            self.window_end = date + timedelta(days=self.windowpad)
 
     def get_files(self, bucket: str) -> Iterable[str]:
         window_range = []
@@ -52,10 +74,12 @@ class XoverProcessor:
 
         ref_tstamp = self.REF_EPOCH.timestamp()
 
-        all_cycle1, all_cycle2 = [], []
-        all_pass1, all_pass2 = [], []
-        all_psec1, all_psec2 = [], []
-        all_ssh1, all_ssh2 = [], []
+        # Accumulate per-file arrays, then concatenate once. Both branches share
+        # the file-open loop and the time1 size==0 skip; the branch chosen by
+        # self.crossover_type decides which variables are read and how dssh is
+        # built (self stacks with a sign flip, reference does not).
+        loader = self._load_reference if self.crossover_type == "reference" else self._load_self
+        accum: dict[str, list] = {}
 
         for file in files:
             with self.open_file(file) as f:
@@ -64,32 +88,59 @@ class XoverProcessor:
                     size = len(nc_file["time1"])
                     if size == 0:
                         continue
-                    all_cycle1.append(nc_file["cycle1"][:])
-                    all_cycle2.append(nc_file["cycle2"][:])
-                    all_pass1.append(nc_file["pass1"][:])
-                    all_pass2.append(nc_file["pass2"][:])
-                    all_ssh1.append(nc_file["ssh1"][:])
-                    all_ssh2.append(nc_file["ssh2"][:])
-                    all_psec1.append(nc_file["time1"][:] + ref_tstamp)
-                    all_psec2.append(nc_file["time2"][:] + ref_tstamp)
+                    loader(nc_file, ref_tstamp, accum)
                 finally:
                     nc_file.close()
 
-        if not all_ssh1:
+        if not accum.get("ssh1"):
             self.dssh = np.array([])
             self.psec = np.array([])
             self.trackid = np.array([])
             logging.info("Loading data complete (no data)")
             return
 
-        cycle1 = np.concatenate(all_cycle1)
-        cycle2 = np.concatenate(all_cycle2)
-        pass1 = np.concatenate(all_pass1)
-        pass2 = np.concatenate(all_pass2)
-        psec1 = np.concatenate(all_psec1)
-        psec2 = np.concatenate(all_psec2)
-        ssh1 = np.concatenate(all_ssh1)
-        ssh2 = np.concatenate(all_ssh2)
+        if self.crossover_type == "reference":
+            self._build_reference(accum)
+        else:
+            self._build_self(accum)
+        logging.info("Loading data complete")
+
+    @staticmethod
+    def _load_self(nc_file, ref_tstamp: float, accum: dict) -> None:
+        """Read one self-schema crossover file into the accumulator."""
+        accum.setdefault("cycle1", []).append(nc_file["cycle1"][:])
+        accum.setdefault("cycle2", []).append(nc_file["cycle2"][:])
+        accum.setdefault("pass1", []).append(nc_file["pass1"][:])
+        accum.setdefault("pass2", []).append(nc_file["pass2"][:])
+        accum.setdefault("ssh1", []).append(nc_file["ssh1"][:])
+        accum.setdefault("ssh2", []).append(nc_file["ssh2"][:])
+        accum.setdefault("psec1", []).append(nc_file["time1"][:] + ref_tstamp)
+        accum.setdefault("psec2", []).append(nc_file["time2"][:] + ref_tstamp)
+
+    @staticmethod
+    def _load_reference(nc_file, ref_tstamp: float, accum: dict) -> None:
+        """Read one reference-schema crossover file into the accumulator.
+
+        The reference schema has no ``time2``/``cycle2``; only the high-lat side
+        vars and the interpolated reference ``ssh2`` are read here.
+        """
+        accum.setdefault("cycle1", []).append(nc_file["cycle1"][:])
+        accum.setdefault("pass1", []).append(nc_file["pass1"][:])
+        accum.setdefault("ssh1", []).append(nc_file["ssh1"][:])
+        accum.setdefault("ssh2", []).append(nc_file["ssh2"][:])
+        accum.setdefault("psec1", []).append(nc_file["time1"][:] + ref_tstamp)
+
+    def _build_self(self, accum: dict) -> None:
+        """Self path: each pair contributes twice with opposite sign (shared
+        orbit error), keyed by both trackids — reproduces the original exactly."""
+        cycle1 = np.concatenate(accum["cycle1"])
+        cycle2 = np.concatenate(accum["cycle2"])
+        pass1 = np.concatenate(accum["pass1"])
+        pass2 = np.concatenate(accum["pass2"])
+        psec1 = np.concatenate(accum["psec1"])
+        psec2 = np.concatenate(accum["psec2"])
+        ssh1 = np.concatenate(accum["ssh1"])
+        ssh2 = np.concatenate(accum["ssh2"])
 
         dssh0 = ssh1 - ssh2
         self.dssh = np.concatenate((dssh0, -dssh0))
@@ -97,7 +148,20 @@ class XoverProcessor:
         self.trackid = np.concatenate(
             (cycle1 * self.TRACKID_CYCLE_FACTOR + pass1, cycle2 * self.TRACKID_CYCLE_FACTOR + pass2)
         )
-        logging.info("Loading data complete")
+
+    def _build_reference(self, accum: dict) -> None:
+        """Reference path: side 2 is the fixed reference-mission truth, not a
+        second observation, so there is no sign-flipped stacking. Each crossover
+        contributes a single ``dssh = ssh1 - ssh2`` at the high-lat time,
+        keyed by the high-lat trackid only (length == n, not 2n)."""
+        cycle1 = np.concatenate(accum["cycle1"])
+        pass1 = np.concatenate(accum["pass1"])
+        ssh1 = np.concatenate(accum["ssh1"])
+        ssh2 = np.concatenate(accum["ssh2"])
+
+        self.dssh = ssh1 - ssh2
+        self.psec = np.concatenate(accum["psec1"])
+        self.trackid = cycle1 * self.TRACKID_CYCLE_FACTOR + pass1
 
     def identify_bad_passes(self, currentdate: float) -> List[Dict[str, str]]:
         bad_passes = []

--- a/pipeline/daily_file_gen/bad_pass/bad_passes/config/source_config.py
+++ b/pipeline/daily_file_gen/bad_pass/bad_passes/config/source_config.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+from utilities.source_profile import (
+    SourceCommon,
+    list_sources_for_stage,
+    load_source_config,
+)
+
+
+@dataclass(kw_only=True, frozen=True)
+class BadPassConfig(SourceCommon):
+    """bad_pass stage config.
+
+    The self/reference dispatch uses the inherited ``product_type``
+    (``reference`` → self stacking, ``high_latitude`` → reference fixed-truth),
+    mirroring the OER stage. bad_pass does no spline fitting, so unlike
+    ``OerConfig`` it needs no ``ground_speed``; only the inherited
+    ``product_type`` (dispatch) and the reference-path window half-width matter.
+
+    ``reference_window_size`` is the half-width (in days) of the *centered*
+    crossover-fetch window used only by the reference path; the self path keeps
+    its historical backward-looking window.
+    """
+
+    reference_window_size: int = 2
+
+
+def get_source_config(source: str) -> BadPassConfig:
+    return load_source_config(BadPassConfig, "bad_pass", source)
+
+
+def get_available_sources() -> list[str]:
+    return list_sources_for_stage("bad_pass")

--- a/pipeline/daily_file_gen/bad_pass/tests/test_bad_pass_flag.py
+++ b/pipeline/daily_file_gen/bad_pass/tests/test_bad_pass_flag.py
@@ -1,8 +1,11 @@
 import json
+import os
+import tempfile
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import mock_open, patch
 
+import netCDF4 as nc
 import numpy as np
 from bad_passes.bad_pass_flag import XoverProcessor
 
@@ -16,12 +19,25 @@ class TestXoverProcessorInit(unittest.TestCase):
 
         self.assertEqual(proc.source, "GSFC")
         self.assertEqual(proc.date, date)
+        # GSFC is product_type: reference → self stacking, backward window.
+        self.assertEqual(proc.crossover_type, "self")
         self.assertEqual(proc.windowlen, 10)
         self.assertEqual(proc.windowpad, 1)
         # window_start = date - 10 days - 1 day = Jan 4
         self.assertEqual(proc.window_start, datetime(2024, 1, 4))
         # window_end = date + 1 day = Jan 16
         self.assertEqual(proc.window_end, datetime(2024, 1, 16))
+
+    def test_init_reference_source_centered_window(self):
+        """S3B is product_type: high_latitude → reference path with a centered
+        window (date - n … date + n)."""
+        date = datetime(2024, 1, 15)
+        proc = XoverProcessor("S3B", date)
+
+        self.assertEqual(proc.crossover_type, "reference")
+        n = proc.config.reference_window_size
+        self.assertEqual(proc.window_start, date - timedelta(days=n))
+        self.assertEqual(proc.window_end, date + timedelta(days=n))
 
 
 class TestGetFiles(unittest.TestCase):
@@ -123,6 +139,88 @@ class TestIdentifyBadPasses(unittest.TestCase):
         result = proc.identify_bad_passes(currentdate)
 
         self.assertEqual(len(result), 0)
+
+
+def _create_reference_xover_nc(path, cycle1, pass1, ssh1, ssh2, time1):
+    """Write a minimal *reference*-schema crossover netCDF.
+
+    Reference crossovers carry the high-lat side + interpolated reference only:
+    there is deliberately **no** ``time2``/``cycle2`` here (reading either would
+    raise on the reference path). ``pass2`` and the ``ref_*`` vars exist in real
+    granules; ``pass2`` is included to prove the reference path ignores it.
+    """
+    ds = nc.Dataset(path, "w", format="NETCDF4")
+    ds.createDimension("time1", len(time1))
+    for name, data, dtype in [
+        ("cycle1", cycle1, "f8"),
+        ("pass1", pass1, "f8"),
+        ("ssh1", ssh1, "f8"),
+        ("ssh2", ssh2, "f8"),
+        ("time1", time1, "f8"),
+        ("pass2", pass1, "f8"),
+    ]:
+        var = ds.createVariable(name, dtype, ("time1",))
+        var[:] = np.asarray(data, dtype=float)
+    ds.close()
+
+
+class TestLoadAllDataReference(unittest.TestCase):
+    """Tests for XoverProcessor.load_all_data on the reference (high_latitude) path."""
+
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(suffix=".nc", delete=False)
+        self.tmpfile.close()
+        self.n = 5
+        # cycle=7, pass=100 for every crossover → single trackid 70100
+        self.cycle1 = np.full(self.n, 7.0)
+        self.pass1 = np.full(self.n, 100.0)
+        self.ssh1 = np.array([0.10, 0.20, 0.30, 0.40, 0.50])
+        self.ssh2 = np.array([0.01, 0.02, 0.03, 0.04, 0.05])
+        self.time1 = np.linspace(0.0, 400.0, self.n)
+        _create_reference_xover_nc(
+            self.tmpfile.name, self.cycle1, self.pass1, self.ssh1, self.ssh2, self.time1
+        )
+
+    def tearDown(self):
+        if os.path.exists(self.tmpfile.name):
+            os.remove(self.tmpfile.name)
+
+    def test_reference_load_no_keyerror_and_unstacked(self):
+        proc = XoverProcessor("S3B", datetime(2024, 1, 15))
+        self.assertEqual(proc.crossover_type, "reference")
+
+        # No KeyError despite the file having no time2/cycle2.
+        proc.load_all_data([self.tmpfile.name])
+
+        # dssh = ssh1 - ssh2, length == n (not 2n), no sign-flipped stacking.
+        self.assertEqual(len(proc.dssh), self.n)
+        np.testing.assert_allclose(proc.dssh, self.ssh1 - self.ssh2)
+
+        # psec = time1 + ref epoch offset, length == n.
+        self.assertEqual(len(proc.psec), self.n)
+        ref_tstamp = XoverProcessor.REF_EPOCH.timestamp()
+        np.testing.assert_allclose(proc.psec, self.time1 + ref_tstamp)
+
+        # A single trackid per crossover keyed by cycle1*10000 + pass1.
+        expected_trackid = 7 * XoverProcessor.TRACKID_CYCLE_FACTOR + 100
+        self.assertEqual(len(proc.trackid), self.n)
+        self.assertTrue(np.all(proc.trackid == expected_trackid))
+
+    def test_reference_empty_file_yields_empty_arrays(self):
+        empty = tempfile.NamedTemporaryFile(suffix=".nc", delete=False)
+        empty.close()
+        try:
+            _create_reference_xover_nc(
+                empty.name, [], [], [], [], np.array([], dtype=float)
+            )
+            proc = XoverProcessor("S3B", datetime(2024, 1, 15))
+            proc.load_all_data([empty.name])
+            self.assertEqual(len(proc.dssh), 0)
+            self.assertEqual(len(proc.psec), 0)
+            self.assertEqual(len(proc.trackid), 0)
+        finally:
+            if os.path.exists(empty.name):
+                os.remove(empty.name)
 
 
 class TestWriteResultsToS3(unittest.TestCase):

--- a/pipeline/daily_file_gen/finalizer/README.md
+++ b/pipeline/daily_file_gen/finalizer/README.md
@@ -8,15 +8,16 @@ Runs as an AWS Lambda (see `Dockerfile`), invoked by a Step Function with a JSON
 
 For each processing date, the Lambda:
 
-1. **Validates the source** against `finalization/config/sources.yaml` and checks the processing date falls within the source's configured date range.
+1. **Validates the source** against its `utilities/sources/{source}.yaml` profile and checks the processing date falls within the source's configured date range.
 2. **Loads bad passes** from `s3://{bucket}/bad_passes/{source}/{date}.json` (optional; returns an empty DataFrame if absent).
 3. **Downloads the P2 daily file** from `s3://{bucket}/daily_files/p2/{source}/{year}/`.
 4. **Writes pass-flag metadata** — `pass_flag_mean_num`, `pass_flag_rms_num`, `pass_flag_mean_threshold`, `pass_flag_rms_threshold`, and `pass_flag_notes` from the source config.
 5. **Applies bad-pass flags** — sets `nasa_flag = 1` for matching cycle/pass rows, NaNs `ssha_smoothed` for flagged observations, and records flagged passes in the `flagged_passes` attribute.
 6. **Handles the absolute offset** — if the source offset is non-zero, removes any previously applied offset (via `absolute_offset_applied` attribute) and adds the configured one to both `ssha` and `ssha_smoothed`.
-7. **Sets global attributes** — `product_generation_step = "3"`, `history`, `granule_id`, `absolute_offset_applied`, and sorts all global attributes alphabetically (case-insensitive).
-8. **Appends a `processing_history` step** (generation step 3) recording the bad-pass/offset application — see [`utilities/provenance.py`](../../../utilities/provenance.py) and ADR 0005.
-9. **Uploads** the finalized P3 file to S3 and removes the local temp copy.
+7. **Applies the intermission-bias correction** — for `high_latitude` sources, subtracts `common.intermission_bias` from `ssha`/`ssha_smoothed` to tie the absolute level onto the reference datum (OER left this in place, fitting only orbit error). Idempotent via the `intermission_bias_applied` attribute (previous value added back before the new one is subtracted). Kept as a separate lever from `offset` — the two are distinct quantities with distinct provenance. No-op for reference sources (`intermission_bias` defaults to `0.0`).
+8. **Sets global attributes** — `product_generation_step = "3"`, `history`, `granule_id`, `absolute_offset_applied`, `intermission_bias_applied`, and sorts all global attributes alphabetically (case-insensitive).
+9. **Appends a `processing_history` step** (generation step 3) recording the bad-pass/offset/intermission-bias application — see [`utilities/provenance.py`](../../../utilities/provenance.py) and ADR 0005.
+10. **Uploads** the finalized P3 file to S3 and removes the local temp copy.
 
 As a **deliverable stage** the handler returns a **Job outcome** (`utilities.job_outcome.JobOutcome`) declaring the P3 key it wrote — the success-side analog of the structured failure entry (ADR 0005). The Distributed Map's `ResultWriter` persists it to `SUCCEEDED_n.json`, and the `run_summary` Lambda reconciles it against the jobs manifest. The outcome's `metadata` carries the file's `processing_history`, a `provenance_complete` flag, and the `product_type`/`unify` source-config fields. An upload failure now **raises** (previously returned silently) so the failure path records it.
 
@@ -29,8 +30,8 @@ finalizer/
 │   ├── finalizer.py                    # Finalizer class + apply_bad_pass()
 │   └── config/
 │       ├── __init__.py
-│       ├── sources.yaml                # Per-source config (offset, pass-flag thresholds)
-│       └── source_config.py            # Dataclasses + YAML loader (lazy-cached)
+│       └── source_config.py            # FinalizerSourceConfig dataclasses + loader
+│                                       # (delegates to utilities/source_profile.py)
 ├── tests/
 │   ├── __init__.py                     # Adds finalization/ to sys.path for test imports
 │   └── test_finalizer.py              # Unit tests
@@ -50,7 +51,7 @@ The Lambda receives one item from the jobs manifest per invocation:
 }
 ```
 
-All three fields are required. Available sources are defined in `finalization/config/sources.yaml`.
+All three fields are required. Available sources are those whose `utilities/sources/{source}.yaml` profile declares a `finalizer:` section (see `get_available_sources`).
 
 ## Lambda output
 
@@ -87,26 +88,28 @@ Filename prefix is determined by the global source registry (`utilities/source_p
 
 ## Source configuration
 
-Each source has settings at two levels:
+Each source is configured in a single profile at `utilities/sources/{source}.yaml`, split into two levels within that file:
 
-**Global registry** (`utilities/sources.yaml`) — shared fields inherited by all stages: `product_type`, `unify`, `start_date`, `end_date`.
+**`common` block** — source-identity fields inherited by every stage (`utilities/source_profile.py`): `product_type`, `unify`, `start_date`, `end_date`, `intermission_bias`, etc.
 
-**Stage-local config** (`finalization/config/sources.yaml`) — finalizer-specific fields merged with the global registry:
+**`finalizer:` section** — finalizer-specific fields, merged over `common` by `finalization/config/source_config.py`:
 
 | Field       | Description                                              |
 |-------------|----------------------------------------------------------|
-| `offset`    | Absolute offset applied to `ssha`/`ssha_smoothed` (m)    |
+| `offset`    | Absolute offset applied to `ssha`/`ssha_smoothed` (m); manual datum tie |
 | `pass_flag` | Thresholds: `mean_num`, `rms_num`, `mean_threshold`, `rms_threshold` |
+| `intermission_bias` | Inherited from `common`. Measured `median(ssh1 − ssh2)` (high_lat − reference); **subtracted** from `ssha`/`ssha_smoothed` for `high_latitude` sources. Defaults to `0.0` (no-op for reference sources) |
 
 Current sources:
 
-| Source | Product Type | Offset  | Start Date | End Date   |
-|--------|-------------|---------|------------|------------|
-| GSFC   | reference   | 0.0     | 1992-10-25 | 2024-01-20 |
-| S6     | reference   | 0.0291  | 2024-01-21 |            |
-| S6B    | reference   | 0.0     | 2025-11-26 |            |
+| Source | Product Type   | Offset  | Intermission Bias | Start Date | End Date   |
+|--------|----------------|---------|-------------------|------------|------------|
+| GSFC   | reference      | 0.0     | 0.0               | 1992-10-25 | 2024-01-20 |
+| S6     | reference      | 0.0291  | 0.0               | 2024-01-21 |            |
+| S6B    | reference      | 0.0     | 0.0               | 2025-11-26 |            |
+| S3B    | high_latitude  | 0.0     | 0.0209            | 2018-11-24 | 2026-04-10 |
 
-To add a new source, add an entry to `utilities/sources.yaml` first, then add the finalizer-specific entry to `finalization/config/sources.yaml`. No code changes required.
+To add a new source, create/extend its `utilities/sources/{source}.yaml` profile with a `common` block and a `finalizer:` section. No code changes required.
 
 ## Step Function
 
@@ -131,6 +134,7 @@ From the repo root (after `uv sync --extra dev`):
 | `TestApplyBadPass`        | Flag matching cycle/pass, `flagged_passes` attr, `ssha_smoothed` NaN, no-match |
 | `TestProcessGSFC`         | Per-source upload path, offset is zero                           |
 | `TestProcessS6`           | Offset applied, previous offset removed before applying          |
+| `TestProcessS3B`          | Intermission bias subtracted, previous bias removed, offset/bias independent |
 | `TestProcessAttributes`   | `product_generation_step`, `history`, `granule_id`, pass-flag attrs, attribute sort |
 | `TestProcessWithBadPasses`| Bad passes applied during `process()`                            |
 | `TestProcessS6B`          | Per-source upload path, granule ID uses source name              |

--- a/pipeline/daily_file_gen/finalizer/finalization/finalizer.py
+++ b/pipeline/daily_file_gen/finalizer/finalization/finalizer.py
@@ -138,6 +138,32 @@ class Finalizer:
 
         ds.absolute_offset_applied = self.config.offset
 
+        # Remove the constant high-lat-vs-reference offset from the absolute SSH
+        # level. OER left this in place (it fits only orbit error); the finalizer
+        # ties ssha to the reference datum. Kept separate from `offset` — the two
+        # are distinct quantities (manual datum tie vs measured crossover median)
+        # and each carries its own provenance attribute. No-op for reference
+        # sources (intermission_bias defaults to 0.0).
+        bias = self.config.intermission_bias
+        if bias != 0.0:
+            try:
+                if "intermission_bias_applied" in ds.ncattrs():
+                    prev_bias = float(ds.intermission_bias_applied)
+                    if prev_bias != 0.0:
+                        ds.variables["ssha"][:] = ds.variables["ssha"][:] + prev_bias
+                        ds.variables["ssha_smoothed"][:] = (
+                            ds.variables["ssha_smoothed"][:] + prev_bias
+                        )
+            except AttributeError as e:
+                logging.exception(f"Error finalizing {filename}: {e}")
+
+            ds.variables["ssha"][:] = ds.variables["ssha"][:] - bias
+            ds.variables["ssha_smoothed"][:] = (
+                ds.variables["ssha_smoothed"][:] - bias
+            )
+
+        ds.intermission_bias_applied = bias
+
         dst_s3_path = self._build_dst_path(bucket)
 
         ds.granule_id = filename
@@ -148,6 +174,7 @@ class Finalizer:
             generation_step=3,
             bad_passes_applied=not self.bad_pass_df.empty,
             absolute_offset_applied=self.config.offset,
+            intermission_bias_applied=bias,
             bad_pass_source=bad_pass_key(self.source, self.processing_date),
         )
         processing_history = read_from_nc(ds)

--- a/pipeline/daily_file_gen/finalizer/tests/test_finalizer.py
+++ b/pipeline/daily_file_gen/finalizer/tests/test_finalizer.py
@@ -21,6 +21,8 @@ from finalization.finalizer import (
 
 # Test constant matching the S6 config value
 S6_OFFSET = 0.0291
+# Test constant matching the S3B common.intermission_bias value
+S3B_BIAS = 0.0209
 
 
 # ---------------------------------------------------------------------------
@@ -28,7 +30,7 @@ S6_OFFSET = 0.0291
 # ---------------------------------------------------------------------------
 
 def _create_test_nc(path, n=10, source="GSFC", add_offset_attr=False,
-                    offset_value=0.0):
+                    offset_value=0.0, add_bias_attr=False, bias_value=0.0):
     """Create a minimal netCDF file with the variables the finalizer expects."""
     ds = nc.Dataset(path, "w", format="NETCDF4")
     ds.createDimension("obs", n)
@@ -50,6 +52,8 @@ def _create_test_nc(path, n=10, source="GSFC", add_offset_attr=False,
 
     if add_offset_attr:
         ds.absolute_offset_applied = offset_value
+    if add_bias_attr:
+        ds.intermission_bias_applied = bias_value
 
     ds.close()
 
@@ -81,6 +85,19 @@ class TestSourceConfig(unittest.TestCase):
         self.assertEqual(cfg.product_type, "reference")
         self.assertEqual(cfg.offset, S6_OFFSET)
         self.assertEqual(cfg.start_date, date(2026, 1, 1))
+        # reference source: no intermission bias
+        self.assertEqual(cfg.intermission_bias, 0.0)
+
+    def test_s3b_config_values(self):
+        """S3B previously TypeError'd (no finalizer: section); it now loads and
+        inherits intermission_bias from common."""
+        cfg = get_source_config("S3B")
+        self.assertEqual(cfg.product_type, "high_latitude")
+        self.assertEqual(cfg.offset, 0.0)
+        self.assertEqual(cfg.intermission_bias, S3B_BIAS)
+
+    def test_s3b_in_available_sources(self):
+        self.assertIn("S3B", get_available_sources())
 
     def test_invalid_source_raises(self):
         with self.assertRaises(ValueError):
@@ -256,12 +273,15 @@ class _ProcessTestMixin:
 
     def _setup_process_mocks(self, mock_aws, source="GSFC",
                              bad_passes_payload=None, add_offset_attr=False,
-                             offset_value=0.0):
+                             offset_value=0.0, add_bias_attr=False,
+                             bias_value=0.0):
         self.nc_src = tempfile.NamedTemporaryFile(suffix=".nc", delete=False)
         self.nc_src.close()
         _create_test_nc(self.nc_src.name, n=5, source=source,
                         add_offset_attr=add_offset_attr,
-                        offset_value=offset_value)
+                        offset_value=offset_value,
+                        add_bias_attr=add_bias_attr,
+                        bias_value=bias_value)
 
         self.uploaded_copy = self.nc_src.name + ".uploaded"
 
@@ -325,6 +345,8 @@ class TestProcessGSFC(unittest.TestCase, _ProcessTestMixin):
             f.process("bucket")
             ds = nc.Dataset(self.uploaded_copy, "r")
             self.assertEqual(float(ds.absolute_offset_applied), 0.0)
+            # reference source: bias defaults to 0.0, block is a no-op
+            self.assertEqual(float(ds.intermission_bias_applied), 0.0)
             ds.close()
         finally:
             self._cleanup()
@@ -389,6 +411,101 @@ class TestProcessS6(unittest.TestCase, _ProcessTestMixin):
             expected = orig_ssha - old_offset + S6_OFFSET
             np.testing.assert_allclose(
                 ds.variables["ssha"][:], expected, atol=1e-10
+            )
+            ds.close()
+        finally:
+            self._cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Tests — process() S3B path (intermission-bias handling)
+# ---------------------------------------------------------------------------
+
+class TestProcessS3B(unittest.TestCase, _ProcessTestMixin):
+
+    @patch("finalization.finalizer.aws_manager")
+    def test_s3b_applies_intermission_bias(self, mock_aws):
+        proc_date = date(2020, 3, 15)
+        self._setup_process_mocks(mock_aws, source="S3B")
+
+        orig_ds = nc.Dataset(self.nc_src.name, "r")
+        orig_ssha = orig_ds.variables["ssha"][:].copy()
+        orig_smoothed = orig_ds.variables["ssha_smoothed"][:].copy()
+        orig_ds.close()
+
+        try:
+            f = Finalizer(proc_date, "S3B", "bucket")
+            f.process("bucket")
+
+            ds = nc.Dataset(self.uploaded_copy, "r")
+            # bias is subtracted (ties absolute level onto the reference datum)
+            np.testing.assert_allclose(
+                ds.variables["ssha"][:], orig_ssha - S3B_BIAS, atol=1e-10
+            )
+            np.testing.assert_allclose(
+                ds.variables["ssha_smoothed"][:], orig_smoothed - S3B_BIAS,
+                atol=1e-10,
+            )
+            self.assertAlmostEqual(
+                float(ds.intermission_bias_applied), S3B_BIAS
+            )
+            ds.close()
+        finally:
+            self._cleanup()
+
+    @patch("finalization.finalizer.aws_manager")
+    def test_s3b_removes_previous_bias_before_applying(self, mock_aws):
+        """A pre-existing intermission_bias_applied is added back before the new
+        bias is subtracted (idempotent re-run)."""
+        proc_date = date(2020, 3, 15)
+        old_bias = 0.015
+        self._setup_process_mocks(
+            mock_aws, source="S3B",
+            add_bias_attr=True, bias_value=old_bias,
+        )
+
+        orig_ds = nc.Dataset(self.nc_src.name, "r")
+        orig_ssha = orig_ds.variables["ssha"][:].copy()
+        orig_ds.close()
+
+        try:
+            f = Finalizer(proc_date, "S3B", "bucket")
+            f.process("bucket")
+
+            ds = nc.Dataset(self.uploaded_copy, "r")
+            expected = orig_ssha + old_bias - S3B_BIAS
+            np.testing.assert_allclose(
+                ds.variables["ssha"][:], expected, atol=1e-10
+            )
+            self.assertAlmostEqual(
+                float(ds.intermission_bias_applied), S3B_BIAS
+            )
+            ds.close()
+        finally:
+            self._cleanup()
+
+    @patch("finalization.finalizer.aws_manager")
+    def test_s3b_offset_and_bias_independent(self, mock_aws):
+        """S3B offset=0.0, so only the bias moves ssha; both provenance attrs
+        coexist independently."""
+        proc_date = date(2020, 3, 15)
+        self._setup_process_mocks(mock_aws, source="S3B")
+
+        orig_ds = nc.Dataset(self.nc_src.name, "r")
+        orig_ssha = orig_ds.variables["ssha"][:].copy()
+        orig_ds.close()
+
+        try:
+            f = Finalizer(proc_date, "S3B", "bucket")
+            f.process("bucket")
+
+            ds = nc.Dataset(self.uploaded_copy, "r")
+            np.testing.assert_allclose(
+                ds.variables["ssha"][:], orig_ssha - S3B_BIAS, atol=1e-10
+            )
+            self.assertEqual(float(ds.absolute_offset_applied), 0.0)
+            self.assertAlmostEqual(
+                float(ds.intermission_bias_applied), S3B_BIAS
             )
             ds.close()
         finally:

--- a/pipeline/infra/run_summary/README.md
+++ b/pipeline/infra/run_summary/README.md
@@ -12,10 +12,12 @@ pipeline succeeds. Given `{jobs_key, bucket, source}` it:
    (`along_track ← {finalizer, unifier}`, `gridded ← {simple_grids, enso}`);
 3. reads `pipeline_init`'s `run_params.json` sidecar (absent ⇒ `{}` ⇒ "scheduled defaults")
    so the notification can report how the run was invoked;
-4. reconciles expected vs produced per **Product pipeline**, collecting `missing`
+4. reads the diagnostic **bad_pass** stage's results (`results/bad_pass/` ResultWriter)
+   and aggregates the flagged-pass counts per date;
+5. reconciles expected vs produced per **Product pipeline**, collecting `missing`
    (and skip reasons) and a per-deliverable `provenance_incomplete` count;
-5. writes the **Run summary** to `pipeline_runs/{source}/{run_id}/summary.json`;
-6. renders and publishes the success SNS.
+6. writes the **Run summary** to `pipeline_runs/{source}/{run_id}/summary.json`;
+7. renders and publishes the success SNS.
 
 ## Reading SUCCEEDED entries
 
@@ -36,7 +38,22 @@ The rendered email:
   on a shortfall) — they are the same P3 file in two prefixes, so a separate row read as a
   phantom failure. `summary.json` still carries both keys;
 - lists produced filenames (basenames) per deliverable, capped at 40 with an `… (N total)`
-  overflow, alongside the `missing` dates and reasons.
+  overflow, alongside the `missing` dates and reasons;
+- adds a **bad passes** diagnostic line *within* the `along_track` section (bad_pass runs
+  inside the along-track chain, between xover_p2 and the finalizer) — the run's total flagged
+  (cycle, pass) count and a per-date breakdown (`2026-02-01: 5`), or `none flagged` when the
+  stage ran but flagged nothing. bad_pass is *not* a deliverable (it produces no P3, so there
+  is nothing to reconcile against the manifest); the line is omitted entirely for runs with no
+  bad_pass results. `summary.json` carries the aggregate under a top-level `bad_passes` key.
+
+## Reading bad_pass results
+
+Unlike the deliverable stages, the bad_pass Map's invoke task does **not** unwrap the Lambda
+result (`Output: {% $states.result.Payload %}`), so its `ResultWriter` writes the raw Lambda
+envelope wrapping the handler return `{date, source, count}`. `read_outcomes` /
+`_outcome_from_entry`'s defensive envelope-unwrap (the same one that guards the deliverable
+stages) yields the `{date, source, count}` payloads, which `summarize_bad_passes` then
+aggregates. `count` is the number of passes flagged for that date.
 
 ## Why it lives in `infra/` but is containerized
 

--- a/pipeline/infra/run_summary/app.py
+++ b/pipeline/infra/run_summary/app.py
@@ -32,8 +32,14 @@ def handler(event, context):
         logger.error("run_summary requires jobs_key and bucket; got %s", event)
         return {"status": "skipped", "reason": "missing jobs_key or bucket"}
 
-    manifests, outcomes, run_params = summarizer.gather(s3, bucket, jobs_key)
-    summary = summarizer.build_summary(jobs_key, manifests, outcomes, run_params=run_params)
+    manifests, outcomes, run_params, bad_pass_results = summarizer.gather(s3, bucket, jobs_key)
+    summary = summarizer.build_summary(
+        jobs_key,
+        manifests,
+        outcomes,
+        run_params=run_params,
+        bad_pass_results=bad_pass_results,
+    )
 
     key = summarizer.summary_key(jobs_key)
     try:

--- a/pipeline/infra/run_summary/summarizer.py
+++ b/pipeline/infra/run_summary/summarizer.py
@@ -122,19 +122,50 @@ def reconcile_pipeline(
     }
 
 
+def summarize_bad_passes(results: list[dict]) -> dict:
+    """Aggregate bad_pass Job results into the Run-summary diagnostics section.
+
+    bad_pass is a **diagnostic** stage, not a deliverable — it produces no P3 and
+    has nothing to reconcile against the manifest, so it lives outside
+    `product_pipelines`. Each result is the bad_pass handler's return
+    (`{date, source, count}`); `count` is how many (cycle, pass) passes were
+    flagged for that date. We surface, per run, the flagged total and the dates
+    it fell on (dates with zero flags are counted as reported but not listed).
+    """
+    per_date: dict[str, int] = {}
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        date = r.get("date")
+        count = r.get("count")
+        if not date or not isinstance(count, int):
+            continue
+        per_date[date] = per_date.get(date, 0) + count
+
+    flagged = {d: c for d, c in per_date.items() if c > 0}
+    return {
+        "dates_reported": len(per_date),
+        "dates_flagged": len(flagged),
+        "total_flagged": sum(flagged.values()),
+        "by_date": [{"date": d, "count": flagged[d]} for d in sorted(flagged)],
+    }
+
+
 def build_summary(
     jobs_key: str,
     manifests: dict[str, list[dict]],
     outcomes: dict[str, dict[str, list[dict]]],
     *,
     run_params: dict | None = None,
+    bad_pass_results: list[dict] | None = None,
     completed_at: str | None = None,
 ) -> dict:
     """Assemble the Run summary artifact.
 
     `manifests` maps a Product-pipeline name to its Job specs; `outcomes` maps a
     Product-pipeline name to its `{stage: [outcome, ...]}`; `run_params` is the
-    pipeline_init invocation sidecar (or `{}` for legacy runs without one). All are
+    pipeline_init invocation sidecar (or `{}` for legacy runs without one);
+    `bad_pass_results` are the bad_pass stage's raw Job results (or `[]`). All are
     passed in (already loaded) so this stays pure and testable.
     """
     source, run_id = jobs_key_identity(jobs_key)
@@ -159,6 +190,7 @@ def build_summary(
         "completed_at": completed_at,
         "parameters": run_params or {},
         "product_pipelines": product_pipelines,
+        "bad_passes": summarize_bad_passes(bad_pass_results or []),
     }
 
 
@@ -254,11 +286,14 @@ def read_run_params(s3, bucket: str, jobs_key: str) -> dict:
     return data if isinstance(data, dict) else {}
 
 
-def gather(s3, bucket: str, jobs_key: str) -> tuple[dict, dict, dict]:
-    """Load all manifests, outcomes, and the params sidecar for a run.
+def gather(s3, bucket: str, jobs_key: str) -> tuple[dict, dict, dict, list[dict]]:
+    """Load all manifests, outcomes, the params sidecar, and bad_pass results.
 
     Manifests + outcomes are keyed by Product-pipeline name; run_params is the flat
-    pipeline_init invocation sidecar (or ``{}`` when absent)."""
+    pipeline_init invocation sidecar (or ``{}`` when absent); bad_pass_results are the
+    diagnostic bad_pass stage's raw Job results (``{date, source, count}``), read from
+    its ResultWriter prefix. bad_pass has no `Output: $states.result.Payload` unwrap in
+    its Map, so `read_outcomes`'s defensive envelope-unwrap is what yields the results."""
     manifests: dict[str, list[dict]] = {}
     outcomes: dict[str, dict[str, list[dict]]] = {}
     for name, cfg in PRODUCT_PIPELINES.items():
@@ -268,7 +303,8 @@ def gather(s3, bucket: str, jobs_key: str) -> tuple[dict, dict, dict]:
             for spec in cfg["deliverables"]
         }
     run_params = read_run_params(s3, bucket, jobs_key)
-    return manifests, outcomes, run_params
+    bad_pass_results = read_outcomes(s3, bucket, stage_results_prefix(jobs_key, "bad_pass"))
+    return manifests, outcomes, run_params, bad_pass_results
 
 
 # ─── SNS rendering ────────────────────────────────────────────────────────
@@ -357,6 +393,30 @@ def _missing_line(missing: list[dict]) -> str:
     return f"  missing: {preview}"
 
 
+def _bad_pass_lines(bp: dict) -> list[str]:
+    """Render the diagnostic bad-pass lines *within* the along_track section: the
+    flagged total across the run and the per-date breakdown (dates with zero flags
+    are not listed). Indented to match the section's deliverable lines. Empty when
+    no bad_pass results were found (a run predating the stage, or none reported)."""
+    if not bp or not bp.get("dates_reported"):
+        return []
+
+    total = bp.get("total_flagged", 0)
+    if total == 0:
+        return ["  bad passes [bad_pass]: none flagged"]
+
+    lines = [
+        f"  bad passes [bad_pass]: {total} flagged across {bp['dates_flagged']} "
+        f"date{'s' if bp['dates_flagged'] != 1 else ''}"
+    ]
+    by_date = bp.get("by_date", [])
+    for entry in by_date[:_MAX_LISTED]:
+        lines.append(f"    {entry['date']}: {entry['count']}")
+    if len(by_date) > _MAX_LISTED:
+        lines.append(f"    … ({len(by_date)} dates total)")
+    return lines
+
+
 def render_notification(summary: dict) -> tuple[str, str]:
     """(subject, body) for the success SNS, rendered from the Run summary artifact."""
     source = summary["source"]
@@ -376,6 +436,10 @@ def render_notification(summary: dict) -> tuple[str, str]:
         lines.append(f"{name} (expected {section['expected']}):")
         if name == "along_track":
             lines += _along_track_lines(section["deliverables"], unified)
+            # bad_pass runs inside the along-track chain (between xover_p2 and the
+            # finalizer); its diagnostic counts belong under this section, not as a
+            # trailing block.
+            lines += _bad_pass_lines(summary.get("bad_passes", {}))
         else:
             for kind, d in section["deliverables"].items():
                 lines += _deliverable_lines(_DELIVERABLE_LABELS.get(kind, kind), d)

--- a/pipeline/infra/run_summary/tests/test_app.py
+++ b/pipeline/infra/run_summary/tests/test_app.py
@@ -39,7 +39,7 @@ class TestRunSummaryHandler(unittest.TestCase):
     @patch("app.s3")
     @patch("app.summarizer")
     def test_happy_path_writes_and_publishes(self, mock_sum, mock_s3, mock_sns):
-        mock_sum.gather.return_value = ({}, {}, {})
+        mock_sum.gather.return_value = ({}, {}, {}, [])
         mock_sum.build_summary.return_value = _summary()
         mock_sum.summary_key.return_value = "runs/summary.json"
         mock_sum.render_notification.return_value = ("subject", "message")
@@ -55,7 +55,7 @@ class TestRunSummaryHandler(unittest.TestCase):
     @patch("app.s3")
     @patch("app.summarizer")
     def test_s3_and_sns_failures_are_swallowed(self, mock_sum, mock_s3, mock_sns):
-        mock_sum.gather.return_value = ({}, {}, {})
+        mock_sum.gather.return_value = ({}, {}, {}, [])
         mock_sum.build_summary.return_value = _summary()
         mock_sum.summary_key.return_value = "runs/summary.json"
         mock_sum.render_notification.return_value = ("subject", "message")

--- a/pipeline/infra/run_summary/tests/test_run_summary.py
+++ b/pipeline/infra/run_summary/tests/test_run_summary.py
@@ -49,6 +49,15 @@ def _succeeded_file(outcomes):
     return json.dumps([{"Input": {}, "Output": o} for o in outcomes]).encode()
 
 
+def _bad_pass_succeeded_file(results):
+    """A bad_pass ResultWriter SUCCEEDED_*.json body. The bad_pass Map has no
+    `Output: $states.result.Payload` unwrap, so each entry's Output is the raw
+    Lambda invoke envelope wrapping the handler return `{date, source, count}`."""
+    return json.dumps([
+        {"Input": {}, "Output": {"Payload": r, "StatusCode": 200}} for r in results
+    ]).encode()
+
+
 def _outcome(stage, date, kind, key, *, status="success", provenance_complete=None,
              skip_reason=None):
     metadata = {}
@@ -371,6 +380,142 @@ class TestRenderNotification(unittest.TestCase):
         }
         _, body = summarizer.render_notification(summary)
         self.assertIn(f"… ({len(outputs)} total)", body)
+
+
+# ---------------------------------------------------------------------------
+# bad_pass aggregation + rendering
+# ---------------------------------------------------------------------------
+
+class TestSummarizeBadPasses(unittest.TestCase):
+
+    def test_empty_results(self):
+        bp = summarizer.summarize_bad_passes([])
+        self.assertEqual(bp["dates_reported"], 0)
+        self.assertEqual(bp["dates_flagged"], 0)
+        self.assertEqual(bp["total_flagged"], 0)
+        self.assertEqual(bp["by_date"], [])
+
+    def test_aggregates_and_sorts_flagged_dates(self):
+        results = [
+            {"date": "2025-01-03", "source": "S6", "count": 2},
+            {"date": "2025-01-01", "source": "S6", "count": 0},
+            {"date": "2025-01-02", "source": "S6", "count": 5},
+        ]
+        bp = summarizer.summarize_bad_passes(results)
+        # all three dates reported, but only two had flags
+        self.assertEqual(bp["dates_reported"], 3)
+        self.assertEqual(bp["dates_flagged"], 2)
+        self.assertEqual(bp["total_flagged"], 7)
+        self.assertEqual(
+            bp["by_date"],
+            [{"date": "2025-01-02", "count": 5}, {"date": "2025-01-03", "count": 2}],
+        )
+
+    def test_ignores_malformed_entries(self):
+        results = [
+            {"date": "2025-01-02", "source": "S6", "count": 3},
+            {"source": "S6", "count": 4},          # no date
+            {"date": "2025-01-05", "source": "S6"},  # no count
+            "not-a-dict",
+        ]
+        bp = summarizer.summarize_bad_passes(results)
+        self.assertEqual(bp["dates_reported"], 1)
+        self.assertEqual(bp["total_flagged"], 3)
+
+
+class TestGatherBadPasses(unittest.TestCase):
+
+    def test_gather_reads_bad_pass_results(self):
+        jobs_key = "pipeline_runs/S6/20250528T120000/jobs.json"
+        prefix = "pipeline_runs/S6/20250528T120000/results/bad_pass/"
+        s3 = FakeS3({
+            prefix + "run/SUCCEEDED_0.json": _bad_pass_succeeded_file([
+                {"date": "2025-01-01", "source": "S6", "count": 2},
+                {"date": "2025-01-02", "source": "S6", "count": 0},
+            ]),
+        })
+        _, _, _, bad_pass_results = summarizer.gather(s3, "b", jobs_key)
+        # the raw Lambda envelope is unwrapped back to the handler return
+        counts = {r["date"]: r["count"] for r in bad_pass_results}
+        self.assertEqual(counts, {"2025-01-01": 2, "2025-01-02": 0})
+
+
+class TestBuildSummaryBadPasses(unittest.TestCase):
+
+    def test_bad_passes_threaded_into_artifact(self):
+        jobs_key = "pipeline_runs/S6/20250528T120000/jobs.json"
+        summary = summarizer.build_summary(
+            jobs_key, {}, {},
+            bad_pass_results=[{"date": "2025-01-02", "source": "S6", "count": 4}],
+            completed_at="t",
+        )
+        self.assertEqual(summary["bad_passes"]["total_flagged"], 4)
+        self.assertEqual(summary["bad_passes"]["by_date"], [{"date": "2025-01-02", "count": 4}])
+
+    def test_bad_passes_default_empty(self):
+        jobs_key = "pipeline_runs/S6/20250528T120000/jobs.json"
+        summary = summarizer.build_summary(jobs_key, {}, {}, completed_at="t")
+        self.assertEqual(summary["bad_passes"]["total_flagged"], 0)
+        self.assertEqual(summary["bad_passes"]["dates_reported"], 0)
+
+
+class TestRenderBadPasses(unittest.TestCase):
+
+    def _summary(self, bad_passes):
+        # bad_pass lines render *within* the along_track section, so the summary
+        # must carry one (mirrors the real artifact from build_summary).
+        return {
+            "source": "S6", "unified_source": None, "run_id": "R1", "completed_at": "t",
+            "parameters": {},
+            "product_pipelines": {
+                "along_track": {
+                    "expected": 1,
+                    "deliverables": {
+                        "daily_file_p3": {"stage": "finalizer", "produced": 1, "skipped": 0,
+                                          "provenance_incomplete": 0, "outputs": []},
+                    },
+                    "missing": [],
+                },
+            },
+            "bad_passes": bad_passes,
+        }
+
+    def test_flagged_rendered_with_breakdown(self):
+        summary = self._summary({
+            "dates_reported": 3, "dates_flagged": 2, "total_flagged": 7,
+            "by_date": [{"date": "2025-01-02", "count": 5}, {"date": "2025-01-03", "count": 2}],
+        })
+        _, body = summarizer.render_notification(summary)
+        self.assertIn("bad passes [bad_pass]: 7 flagged across 2 dates", body)
+        self.assertIn("2025-01-02: 5", body)
+        self.assertIn("2025-01-03: 2", body)
+        # rendered inside the along_track section, before its trailing blank line
+        at_idx = body.index("along_track (expected 1):")
+        gridded_or_end = body.find("\n\n", at_idx)
+        self.assertIn("bad passes", body[at_idx:gridded_or_end])
+
+    def test_none_flagged_rendered(self):
+        summary = self._summary({
+            "dates_reported": 4, "dates_flagged": 0, "total_flagged": 0, "by_date": [],
+        })
+        _, body = summarizer.render_notification(summary)
+        self.assertIn("bad passes [bad_pass]: none flagged", body)
+
+    def test_absent_section_when_no_results(self):
+        summary = self._summary({
+            "dates_reported": 0, "dates_flagged": 0, "total_flagged": 0, "by_date": [],
+        })
+        _, body = summarizer.render_notification(summary)
+        self.assertNotIn("bad passes", body)
+
+    def test_singular_date_grammar(self):
+        summary = self._summary({
+            "dates_reported": 1, "dates_flagged": 1, "total_flagged": 3,
+            "by_date": [{"date": "2025-01-02", "count": 3}],
+        })
+        _, body = summarizer.render_notification(summary)
+        self.assertIn("across 1 date", body)
+        self.assertNotIn("across 1 dates", body)
 
 
 class TestBuildSummaryParameters(unittest.TestCase):

--- a/pipeline/other_products/simple_grids/README.md
+++ b/pipeline/other_products/simple_grids/README.md
@@ -88,10 +88,22 @@ exception with a JSON body containing `status`, `errorType`, `errorMessage`, and
 | Path | Description |
 |------|-------------|
 | `daily_files/p3/{source}/{year}/{prefix}_{YYYYMMDD}.nc` | Input P3 daily files (read, 10-day window) |
-| `simple_grids/{source}/{year}/{source}_alt_ref_simple_grid_v1_1_{YYYYMMDD}.nc` | Output half-degree grid (write) |
+| `simple_grids/{source}/{year}/{source}_alt_ref_simple_grid_v1_1_{YYYYMMDD}.nc` | Output half-degree grid (write, `reference` sources) |
+| `simple_grids/{source}/{year}/{source}_alt_hilat_simple_grid_v1_1_{YYYYMMDD}.nc` | Output half-degree grid (write, `high_latitude` sources) |
 | `simple_grids/quart_deg/{source}/{year}/{source}_alt_ref_simple_grid_v1_1_quart_{YYYYMMDD}.nc` | Output quarter-degree grid (write, when `resolution="quart"`) |
 
-Filename prefix for daily files is determined by the global source registry (`utilities/source_profile.py`).
+Both the daily-file input prefix and the simple-grid output prefix are determined by the global
+source registry (`utilities/source_profile.py` + `utilities/products.yaml`), keyed on the source's
+`product_type`: `reference` sources produce `_alt_ref_simple_grid_` grids, `high_latitude` sources
+(e.g. S3B) produce `_alt_hilat_simple_grid_` grids.
+
+> **Known limitation (high-latitude sources).** The gridding math is source-agnostic, but the
+> output's CF **global attributes** (`title`, `product_short_name`, DOIs, `summary`, `source_url`,
+> etc. in `gridding.py`) are currently hardcoded to the NASA-SSH *reference* product. On a
+> `high_latitude` grid the `ssha`/`counts`/`basin_flag` data are correct, but those descriptive
+> attributes mislabel the product. They must be parametrized per `product_type` before high-lat
+> grids are shipped as a standalone product; they are adequate for internal validation
+> (e.g. `tools/compute_source_offset.py`).
 
 ## Step Function
 

--- a/pipeline/other_products/simple_grids/tests/test_simple_grids.py
+++ b/pipeline/other_products/simple_grids/tests/test_simple_grids.py
@@ -1,5 +1,9 @@
 import unittest
+from datetime import datetime
 from unittest.mock import patch
+
+import numpy as np
+import xarray as xr
 
 
 class TestSimpleGridsHandlerOutcome(unittest.TestCase):
@@ -57,6 +61,179 @@ class TestSimpleGridderKey(unittest.TestCase):
         self.assertTrue(job.key.startswith("simple_grids/quart_deg/S6/2025/"))
         # dst stays consistent with the key
         self.assertTrue(job.dst.endswith(job.key))
+
+    def test_high_latitude_source_uses_hilat_filename(self):
+        """A high_latitude source (S3B) resolves the simple_grid_high_latitude
+        product; previously this raised ValueError because that product was not
+        registered. The filename mirrors the along-track _alt_hilat_ convention."""
+        from simple_gridder.gridder import SimpleGridderJob
+
+        job = SimpleGridderJob("2025-01-07", "b", "S3B", None)
+        self.assertEqual(
+            job.key,
+            "simple_grids/S3B/2025/S3B_alt_hilat_simple_grid_v1_1_20250107.nc",
+        )
+
+
+class TestGenerateKeys(unittest.TestCase):
+    """Date windowing + P3 key generation (the 10-day [center-5, center+4] window)."""
+
+    def _job(self, date="2025-01-07", source="S6", resolution=None):
+        from simple_gridder.gridder import SimpleGridderJob
+
+        return SimpleGridderJob(date, "b", source, resolution)
+
+    def test_window_bounds(self):
+        job = self._job()
+        self.assertEqual(job.center_date, datetime(2025, 1, 7))
+        # window is center-5 .. center+4 (start_date + 9 days)
+        self.assertEqual(job.start_date, datetime(2025, 1, 2))
+        self.assertEqual(job.end_date, datetime(2025, 1, 11))
+
+    def test_generates_ten_daily_keys(self):
+        keys = self._job().generate_keys()
+        self.assertEqual(len(keys), 10)
+
+    def test_key_endpoints_and_prefix(self):
+        keys = self._job().generate_keys()
+        # inclusive of both window ends; reads the P3 lifecycle version
+        self.assertEqual(
+            keys[0], "s3://b/daily_files/p3/S6/2025/S6_alt_ref_at_v1_1_20250102.nc"
+        )
+        self.assertEqual(
+            keys[-1], "s3://b/daily_files/p3/S6/2025/S6_alt_ref_at_v1_1_20250111.nc"
+        )
+
+    def test_window_spans_year_and_month_boundaries(self):
+        # center Jan 3 → window Dec 29 .. Jan 7, so keys cross into 2024/12
+        keys = self._job(date="2025-01-03").generate_keys()
+        self.assertEqual(len(keys), 10)
+        self.assertIn("daily_files/p3/S6/2024/S6_alt_ref_at_v1_1_20241229.nc", keys[0])
+        self.assertIn("daily_files/p3/S6/2025/S6_alt_ref_at_v1_1_20250107.nc", keys[-1])
+
+    def test_high_latitude_source_reads_hilat_daily_files(self):
+        keys = self._job(source="S3B").generate_keys()
+        self.assertTrue(
+            all("S3B_alt_hilat_at_v1_1_" in k for k in keys),
+            "high_latitude source must read _alt_hilat_ P3 daily files",
+        )
+
+
+class TestDsEncoding(unittest.TestCase):
+    """Per-variable NetCDF encoding: compression + dtype/_FillValue overrides."""
+
+    def _encoding(self):
+        from simple_gridder.gridder import SimpleGridderJob
+
+        job = SimpleGridderJob("2025-01-07", "b", "S6", None)
+        ds = xr.Dataset(
+            {
+                "ssha": (("latitude", "longitude"), np.zeros((2, 2))),
+                "counts": (("latitude", "longitude"), np.zeros((2, 2))),
+                "basin_flag": (("latitude", "longitude"), np.zeros((2, 2))),
+            },
+            coords={"latitude": [0.0, 1.0], "longitude": [0.0, 1.0]},
+        )
+        return job.ds_encoding(ds)
+
+    def test_ssha_is_float64_with_max_fill(self):
+        enc = self._encoding()["ssha"]
+        self.assertEqual(enc["dtype"], "float64")
+        self.assertEqual(enc["_FillValue"], np.finfo(np.float64).max)
+        self.assertTrue(enc["zlib"])
+        self.assertEqual(enc["complevel"], 5)
+
+    def test_counts_and_basin_flag_are_int32_with_max_fill(self):
+        enc = self._encoding()
+        for var in ("counts", "basin_flag"):
+            self.assertEqual(enc[var]["dtype"], "int32", var)
+            self.assertEqual(enc[var]["_FillValue"], np.iinfo(np.int32).max, var)
+
+    def test_time_uses_reference_epoch_units(self):
+        enc = self._encoding()["time"]
+        self.assertEqual(enc["units"], "seconds since 1990-01-01 00:00:00")
+        self.assertEqual(enc["dtype"], "float64")
+        self.assertIsNone(enc["_FillValue"])
+
+    def test_lat_lon_are_float32_uncompressed_coords(self):
+        enc = self._encoding()
+        for var in ("latitude", "longitude"):
+            self.assertEqual(enc[var]["dtype"], "float32", var)
+            self.assertIsNone(enc[var]["_FillValue"], var)
+
+
+class TestSource(unittest.TestCase):
+    """Source field selection: prefers ssha_smoothed, falls back to legacy ssh_smoothed."""
+
+    def _ds(self, **extra_vars):
+        base = {
+            "basin_flag": ("t", np.array([1, 2])),
+            "longitude": ("t", np.array([10.0, 20.0])),
+            "latitude": ("t", np.array([1.0, 2.0])),
+        }
+        base.update(extra_vars)
+        return xr.Dataset(base)
+
+    def test_prefers_ssha_smoothed(self):
+        from simple_gridder.gridding import Source
+
+        ds = self._ds(
+            ssha_smoothed=("t", np.array([1.0, 2.0])),
+            ssh_smoothed=("t", np.array([9.0, 9.0])),
+        )
+        np.testing.assert_array_equal(Source(ds).smssh, [1.0, 2.0])
+
+    def test_falls_back_to_legacy_ssh_smoothed(self):
+        from simple_gridder.gridding import Source
+
+        ds = self._ds(ssh_smoothed=("t", np.array([5.0, 6.0])))
+        np.testing.assert_array_equal(Source(ds).smssh, [5.0, 6.0])
+
+
+class TestMergeGranulesThreshold(unittest.TestCase):
+    """The coverage guard: below 150k valid points, merge_granules raises
+    InsufficientData (which make_grid catches → empty grid)."""
+
+    def _gridder(self, streamed_files):
+        from simple_gridder.gridding import Gridder
+
+        return Gridder(
+            datetime(2025, 1, 7),
+            datetime(2025, 1, 2),
+            datetime(2025, 1, 11),
+            ["f.nc"],
+            streamed_files,
+            None,
+        )
+
+    @patch("simple_gridder.gridding.xr.open_mfdataset")
+    def test_below_threshold_raises_insufficient_data(self, mock_open):
+        from simple_gridder.gridding import InsufficientData
+
+        n = 100  # well below the 150000 threshold
+        ds = xr.Dataset(
+            {"ssha_smoothed": ("time", np.ones(n))},
+            coords={"time": np.arange(n)},
+        )
+        mock_open.return_value = ds
+
+        gridder = self._gridder(["obj"])
+        with self.assertRaises(InsufficientData):
+            gridder.merge_granules()
+
+    @patch("simple_gridder.gridding.xr.open_mfdataset")
+    def test_empty_window_raises_insufficient_data(self, mock_open):
+        from simple_gridder.gridding import InsufficientData
+
+        ds = xr.Dataset(
+            {"ssha_smoothed": ("time", np.array([], dtype=float))},
+            coords={"time": np.array([], dtype=float)},
+        )
+        mock_open.return_value = ds
+
+        gridder = self._gridder([])
+        with self.assertRaises(InsufficientData):
+            gridder.merge_granules()
 
 
 if __name__ == "__main__":

--- a/tools/compute_source_offset.py
+++ b/tools/compute_source_offset.py
@@ -98,7 +98,7 @@ def list_s3_grids(s3_client, bucket: str, source: str) -> dict[date, str]:
 def list_local_grids(directory: str) -> dict[date, str]:
     """Return {date: local_path} for all half-degree simple grids in a directory."""
     keys: dict[date, str] = {}
-    for path in Path(directory).glob("*.nc"):
+    for path in Path(directory).glob("**/*.nc"):
         d = _parse_grid_date(path.name)
         if d is not None:
             keys[d] = str(path)

--- a/utilities/products.yaml
+++ b/utilities/products.yaml
@@ -8,6 +8,9 @@ products:
   simple_grid_reference:
     version: "v1_1"
     filename_template: "{source}_alt_ref_simple_grid_{version}_{YYYYMMDD}.nc"
+  simple_grid_high_latitude:
+    version: "v1_1"
+    filename_template: "{source}_alt_hilat_simple_grid_{version}_{YYYYMMDD}.nc"
   enso:
     version: "v1_1"
     filename_template: "ENSO_{YYYYMMDD}.nc"

--- a/utilities/sources/S3B.yaml
+++ b/utilities/sources/S3B.yaml
@@ -21,6 +21,18 @@ daily_files:
   smoothing:
     sigma: 15
 
+finalizer:
+  # offset is a manual datum tie, kept as a separate lever from the measured
+  # intermission_bias (read from common). For S3B the intermission bias is the
+  # absolute tie, so offset is a deliberate no-op; future high-lat sources may
+  # need it. See PLAN_reference_crossovers_bad_pass.md Part B.
+  offset: 0.0
+  pass_flag:
+    mean_num: 15.0
+    rms_num: 25.0
+    mean_threshold: 0.1
+    rms_threshold: 0.27
+
 xover:
   crossover_type: reference
   reference_source: NASA-SSH


### PR DESCRIPTION
Extends high-latitude source support (S3B) through the remaining downstream stages, following the reference-crossover OER work already landed.

## Changes
- **bad_pass** — dispatch self vs reference crossovers from `product_type`; add a reference load path (unstacked `ssh1 − ssh2`, centered window) so high-lat sources no longer error.
- **finalizer** — subtract the per-source `intermission_bias` from the absolute `ssha`/`ssha_smoothed` level, tying high-lat output to the reference datum; add the missing S3B finalizer config.
- **simple_grids** — register the high-latitude simple-grid product so the stage runs on S3B; expand test coverage.
- **run_summary** — report flagged bad-pass counts in the along-track notification.

## Validation
S3B P3 → simple grids → compared against NASA-SSH over the full record:
area-weighted datum tie of **+0.18 mm** (|lat| ≤ 66°), flat in latitude with no basin-scale structure.