### PR TITLE
Retry transient granule downloads for AVISO L2P (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `key_exists()` check that 404'd before an upstream file landed poisoned the listing for
   that whole directory across warm-Lambda invocations. Disabled the listing cache
   (`use_listings_cache=False`) so each check issues a fresh per-key `head_object`.
+- AVISO L2P (S3B) granule downloads now retry transient body-read/decompress errors (up to 5
+  attempts, exponential backoff). A granule still unrecoverable after retries fails the job
+  closed rather than writing a partial daily file, so the date self-heals on the next run. See
+  issue #41.
 
 ## [2.3.0] - 2026-07-15
 

--- a/pipeline/daily_file_gen/daily_files/daily_files/fetching/downloader.py
+++ b/pipeline/daily_file_gen/daily_files/daily_files/fetching/downloader.py
@@ -1,5 +1,6 @@
 import gzip
 import logging
+import time
 from abc import ABC, abstractmethod
 from datetime import datetime
 from io import BytesIO
@@ -9,6 +10,12 @@ import requests
 import s3fs
 
 from utilities.aws_utils import aws_manager
+
+# Transient errors worth retrying at the download level. The mounted urllib3
+# adapter already retries connect/read/5xx *before* the response is returned;
+# these cover the streamed body read + gzip.decompress phase, which happens
+# after the 200 and so is invisible to the adapter.
+_RETRYABLE = (requests.exceptions.RequestException, gzip.BadGzipFile, OSError)
 
 
 def get_podaac_s3_credentials() -> dict:
@@ -31,6 +38,17 @@ class Downloader(ABC):
         ...
 
     def download_all(self, uris: list[str]) -> list:
+        """Download every URI, failing closed on the first unrecoverable one.
+
+        This intentionally does NOT skip failed granules and return a partial
+        result: a partial daily file would be written with fewer granules than
+        exist upstream, and planning (plan_jobs) only replans a date when an
+        upstream granule is *newer* than the existing product — so the gap would
+        never heal. Raising instead leaves no p1 for the date, which DOES replan
+        on the next run. Per-granule transient errors are handled by the
+        downloader's own retry (see HttpDownloader.download); only genuinely
+        unrecoverable granules reach here and abort the job.
+        """
         return [self.download(uri) for uri in uris]
 
 
@@ -63,19 +81,48 @@ class HttpDownloader(Downloader):
     pass directly to xr.open_dataset / netCDF4.Dataset(memory=...).
     """
 
-    def __init__(self, session_fn: Callable[[], requests.Session]):
+    def __init__(
+        self,
+        session_fn: Callable[[], requests.Session],
+        max_attempts: int = 5,
+        backoff_base: float = 1.0,
+        backoff_max: float = 30.0,
+    ):
         self.session = session_fn()
+        self.max_attempts = max_attempts
+        self.backoff_base = backoff_base
+        self.backoff_max = backoff_max
+
+    def _fetch(self, uri: str) -> BytesIO:
+        with self.session.get(uri, stream=True, timeout=120) as resp:
+            resp.raise_for_status()
+            raw = resp.raw
+            raw.decode_content = True
+            if uri.endswith(".gz"):
+                return BytesIO(gzip.decompress(raw.read()))
+            return BytesIO(raw.read())
 
     def download(self, uri: str) -> BytesIO:
-        try:
-            logging.debug(f"Downloading {uri}")
-            with self.session.get(uri, stream=True, timeout=120) as resp:
-                resp.raise_for_status()
-                raw = resp.raw
-                raw.decode_content = True
-                if uri.endswith(".gz"):
-                    return BytesIO(gzip.decompress(raw.read()))
-                return BytesIO(raw.read())
-        except Exception as e:
-            logging.exception(f"Error downloading {uri}")
-            raise e
+        """Download a single granule, retrying transient errors with backoff.
+
+        Retries cover the streamed body read + decompress phase (see _RETRYABLE);
+        the mounted adapter handles connect/read/5xx within each attempt. After
+        max_attempts the last error is re-raised so the job fails closed.
+        """
+        logging.debug(f"Downloading {uri}")
+        for attempt in range(self.max_attempts):
+            try:
+                return self._fetch(uri)
+            except _RETRYABLE as e:
+                if attempt + 1 >= self.max_attempts:
+                    logging.exception(
+                        f"Error downloading {uri} after {self.max_attempts} attempts"
+                    )
+                    raise
+                delay = min(self.backoff_base * 2**attempt, self.backoff_max)
+                logging.warning(
+                    f"Transient error downloading {uri} "
+                    f"(attempt {attempt + 1}/{self.max_attempts}): {e}. "
+                    f"Retrying in {delay:.1f}s"
+                )
+                time.sleep(delay)

--- a/pipeline/daily_file_gen/daily_files/tests/test_http_downloader.py
+++ b/pipeline/daily_file_gen/daily_files/tests/test_http_downloader.py
@@ -24,7 +24,8 @@ class TestHttpDownloader(unittest.TestCase):
     def _make_downloader(self, payload: bytes) -> HttpDownloader:
         session = mock.MagicMock(spec=requests.Session)
         session.get.return_value = _mock_response_raw(payload)
-        return HttpDownloader(session_fn=lambda: session)
+        # backoff_base=0 keeps retry-path tests instant.
+        return HttpDownloader(session_fn=lambda: session, backoff_base=0)
 
     def test_gz_uri_is_decompressed(self):
         body = b"hello world" * 100
@@ -56,18 +57,60 @@ class TestHttpDownloader(unittest.TestCase):
         ])
         self.assertEqual([r.read() for r in results], [b"AAA", b"BBB"])
 
-    def test_http_error_propagates(self):
+    def test_http_error_raises_after_exhausting_retries(self):
         session = mock.MagicMock(spec=requests.Session)
         resp = mock.MagicMock()
         resp.__enter__.return_value = resp
         resp.__exit__.return_value = False
-        resp.raise_for_status.side_effect = requests.HTTPError("401 Unauthorized")
+        resp.raise_for_status.side_effect = requests.HTTPError("500 Server Error")
         session.get.return_value = resp
-        dl = HttpDownloader(session_fn=lambda: session)
+        dl = HttpDownloader(session_fn=lambda: session, max_attempts=3, backoff_base=0)
         # assertLogs captures the ERROR-level traceback HttpDownloader emits
         # before re-raising, so it doesn't pollute test output.
         with self.assertLogs(level="ERROR"), self.assertRaises(requests.HTTPError):
             dl.download("https://example.com/file.nc.gz")
+        # Retried up to the cap before failing closed.
+        self.assertEqual(session.get.call_count, 3)
+
+    def test_download_retries_then_succeeds(self):
+        body = gzip.compress(b"recovered")
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.side_effect = [
+            requests.exceptions.ChunkedEncodingError("connection reset"),
+            _mock_response_raw(body),
+        ]
+        dl = HttpDownloader(session_fn=lambda: session, max_attempts=5, backoff_base=0)
+        buf = dl.download("https://example.com/file.nc.gz")
+        self.assertEqual(buf.read(), b"recovered")
+        self.assertEqual(session.get.call_count, 2)
+
+    def test_non_retryable_error_propagates_immediately(self):
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.side_effect = ValueError("programmer error")
+        dl = HttpDownloader(session_fn=lambda: session, max_attempts=5, backoff_base=0)
+        with self.assertRaises(ValueError):
+            dl.download("https://example.com/file.nc.gz")
+        # No retry on non-transient errors.
+        self.assertEqual(session.get.call_count, 1)
+
+    def test_download_all_fails_closed_on_unrecoverable_granule(self):
+        good = _mock_response_raw(gzip.compress(b"AAA"))
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.side_effect = [
+            good,
+            requests.exceptions.ConnectionError("granule 2 is down"),
+            requests.exceptions.ConnectionError("granule 2 is down"),
+        ]
+        dl = HttpDownloader(session_fn=lambda: session, max_attempts=2, backoff_base=0)
+        # A single unrecoverable granule aborts the whole job rather than
+        # returning a partial list (which would silently drop data upstream).
+        with self.assertLogs(level="ERROR"), self.assertRaises(
+            requests.exceptions.ConnectionError
+        ):
+            dl.download_all([
+                "https://example.com/a.nc.gz",
+                "https://example.com/b.nc.gz",
+            ])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Retries transient body-read/decompress errors on AVISO L2P (S3B) granule downloads (5 attempts, exponential backoff). If a granule is still unrecoverable, the job fails closed rather than writing a partial daily file — the date self-heals on the next run.

Closes #41.